### PR TITLE
feat(editor): UX pass — template preview · convert chip · image folding · AI draft bar + parser dedupe

### DIFF
--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from "next/server";
+import { invokeAgent } from "@/lib/agents/invoke";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Body = {
+  agent: string;
+  /** User's natural-language request, e.g. "write a tweet about X". */
+  instruction: string;
+  /** Existing markdown in the editor — given as context so the agent can
+   *  continue the user's voice instead of writing in isolation. */
+  context?: string;
+  model?: string;
+};
+
+function buildDraftPrompt(args: { instruction: string; context: string }): string {
+  const ctx = args.context.trim();
+  return `你正在为用户起草一段 **markdown** 内容（不是 HTML，不是 JSON，不是代码）。
+
+【硬性规则】
+1. 只输出 markdown 正文，不要任何前后解释、不要 \`\`\`md 围栏、不要"以下是…"开头。
+2. 第一个字符就是正文。最后一个字符是正文末尾。
+3. 不要捏造数据、不要凭空添加引用链接。
+4. 标题、列表、强调、引用、代码块按 markdown 语法书写。
+5. 如果用户没有指定语言，使用与"已有内容"一致的语言；都没有就用中文。
+6. 长度控制：除非用户明确要求长文，控制在 300 字以内。
+
+【用户当前编辑器里的内容（可能为空）】
+${ctx ? ctx : "（空）"}
+
+【用户的需求】
+${args.instruction}
+`;
+}
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return new Response("invalid JSON body", { status: 400 });
+  }
+  const { agent, instruction, context = "", model } = body;
+  if (!agent || !instruction?.trim()) {
+    return new Response("missing required fields: agent, instruction", {
+      status: 400,
+    });
+  }
+
+  const prompt = buildDraftPrompt({ instruction, context });
+
+  const abortCtl = new AbortController();
+  req.signal?.addEventListener("abort", () => abortCtl.abort(), { once: true });
+
+  const stream = invokeAgent({
+    agent,
+    prompt,
+    model,
+    signal: abortCtl.signal,
+  });
+
+  const sse = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      let outClosed = false;
+      const send = (event: string, data: unknown) => {
+        if (outClosed) return;
+        try {
+          controller.enqueue(
+            enc.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+          );
+        } catch {
+          outClosed = true;
+        }
+      };
+
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+          send(value.type, value);
+        }
+      } catch (err) {
+        send("error", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        outClosed = true;
+        try {
+          controller.close();
+        } catch {}
+      }
+    },
+    cancel() {
+      abortCtl.abort();
+    },
+  });
+
+  return new Response(sse, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { PreviewPane } from "@/components/preview-pane";
 import { TasksSidebar } from "@/components/tasks-sidebar";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { SettingsModal } from "@/components/settings-modal";
+import { ConvertChip } from "@/components/convert-chip";
 import { useStore } from "@/lib/store";
 
 export default function Home() {
@@ -48,23 +49,26 @@ export default function Home() {
         style={{ borderTop: "1px solid var(--line-faint)" }}
       >
         <TasksSidebar />
-        {layoutMode !== "preview" && (
-          <section
-            className="flex min-w-0 flex-1 basis-0 flex-col"
-            style={
-              layoutMode === "split"
-                ? { borderRight: "1px solid var(--line-faint)" }
-                : undefined
-            }
-          >
-            <EditorPane />
-          </section>
-        )}
-        {layoutMode !== "editor" && (
-          <section className="flex min-w-0 flex-1 basis-0 flex-col">
-            <PreviewPane iframeRef={iframeRef} />
-          </section>
-        )}
+        <div className="relative flex flex-1 min-w-0">
+          {layoutMode !== "preview" && (
+            <section
+              className="flex min-w-0 flex-1 basis-0 flex-col"
+              style={
+                layoutMode === "split"
+                  ? { borderRight: "1px solid var(--line-faint)" }
+                  : undefined
+              }
+            >
+              <EditorPane />
+            </section>
+          )}
+          {layoutMode !== "editor" && (
+            <section className="flex min-w-0 flex-1 basis-0 flex-col">
+              <PreviewPane iframeRef={iframeRef} />
+            </section>
+          )}
+          <ConvertChip />
+        </div>
       </div>
       {welcomeOpen && <WelcomeModal onClose={() => setWelcomeOpen(false)} />}
       {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}

--- a/src/components/ai-prompt-bar.tsx
+++ b/src/components/ai-prompt-bar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { useStore } from "@/lib/store";
+import { useT } from "@/lib/i18n";
+import { useDraft } from "@/lib/use-draft";
+
+/**
+ * Sticky one-line input pinned to the bottom of the editor's Text tab. The
+ * user types a natural-language instruction ("write a tweet about X"); the
+ * selected agent streams a markdown draft that's appended below the current
+ * editor content. Convert (HTML output) is unaffected — this is a separate
+ * /api/draft endpoint that prompts the agent for plain markdown.
+ */
+export function AiPromptBar() {
+  const [value, setValue] = useState("");
+  const agent = useStore((s) => s.selectedAgent);
+  const { run, cancel, status, error } = useDraft();
+  const t = useT();
+
+  const isRunning = status === "running";
+  const canSubmit = !!agent && !!value.trim() && !isRunning;
+
+  const onSubmit = () => {
+    if (isRunning) {
+      cancel();
+      return;
+    }
+    if (!canSubmit) return;
+    const instruction = value.trim();
+    setValue("");
+    run({ instruction });
+  };
+
+  return (
+    <div
+      className="border-t px-3 py-2"
+      style={{
+        borderColor: "var(--line-faint)",
+        background: "var(--paper)",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden className="shrink-0 text-[14px] opacity-60">✨</span>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
+          placeholder={agent ? t("aiPrompt.placeholder") : t("aiPrompt.needAgent")}
+          disabled={!agent || isRunning}
+          className="min-w-0 flex-1 rounded-full px-3.5 py-1.5 text-[12.5px] outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          style={{
+            background: "var(--surface)",
+            border: "1px solid var(--line)",
+            color: "var(--ink)",
+          }}
+        />
+        <button
+          onClick={onSubmit}
+          disabled={!isRunning && !canSubmit}
+          className="shrink-0 rounded-full px-3 py-1.5 text-[11.5px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
+          style={{
+            background: isRunning ? "var(--coral)" : "var(--ink)",
+            color: "#fff",
+            border: "1px solid transparent",
+          }}
+          title={t("aiPrompt.hint")}
+        >
+          {isRunning ? t("aiPrompt.stop") : t("aiPrompt.submit")}
+          <span className="ml-1.5 hidden text-[10px] opacity-60 sm:inline">⌘↵</span>
+        </button>
+      </div>
+      {error && (
+        <div className="mt-1 text-[11px]" style={{ color: "var(--red)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/convert-chip.tsx
+++ b/src/components/convert-chip.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useStore, selectActiveTask } from "@/lib/store";
+import { useT } from "@/lib/i18n";
+import { useConvert } from "@/lib/use-convert";
+
+/**
+ * Floating chip pinned to the editor / preview divider that runs the same
+ * Convert action as the toolbar button. Mirrors `Toolbar`'s logic but stays
+ * close to the editor so users notice it after editing without traveling
+ * back up to the top bar. Toolbar's own button (and ⌘+Enter shortcut) stay.
+ */
+export function ConvertChip() {
+  const agent = useStore((s) => s.selectedAgent);
+  const agents = useStore((s) => s.agents);
+  const agentModels = useStore((s) => s.agentModels);
+  const activeTaskId = useStore((s) => s.activeTaskId);
+  const template = useStore((s) => selectActiveTask(s)?.templateId ?? "article-magazine");
+  const content = useStore((s) => selectActiveTask(s)?.content ?? "");
+  const format = useStore((s) => selectActiveTask(s)?.format ?? "text");
+  const status = useStore((s) => selectActiveTask(s)?.status ?? "idle");
+  const layoutMode = useStore((s) => s.layoutMode);
+  const { run, cancel } = useConvert();
+  const t = useT();
+
+  // Only show in split mode — when only one pane is visible there's no
+  // divider to hang off, and the toolbar button is already obvious.
+  if (layoutMode !== "split") return null;
+
+  const agentInfo = agents.find((a) => a.id === agent);
+  const model = agent ? agentModels[agent] ?? "default" : "default";
+  const canConvert =
+    !!agent && !!content.trim() && status !== "running" && !agentInfo?.unsupported;
+
+  const isRunning = status === "running";
+
+  const tip = !agent
+    ? t("toolbar.firstSelectAgent")
+    : agentInfo?.unsupported
+      ? t("toolbar.unsupportedProtocol")
+      : !content.trim()
+        ? t("toolbar.enterContent")
+        : t("convertChip.tooltip");
+
+  const onClick = () => {
+    if (isRunning) {
+      cancel(activeTaskId);
+      return;
+    }
+    if (!canConvert) return;
+    run({ taskId: activeTaskId, agent: agent!, templateId: template, content, format, model });
+  };
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-y-0 left-1/2 z-30 flex items-center"
+      style={{ transform: "translateX(-50%)" }}
+    >
+      <button
+        onClick={onClick}
+        disabled={!isRunning && !canConvert}
+        title={tip}
+        aria-label={t("convertChip.label")}
+        className="pointer-events-auto group relative flex items-center gap-2 rounded-full px-4 py-2.5 text-[12.5px] font-medium shadow-lg transition-all hover:scale-[1.02] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
+        style={{
+          background: isRunning
+            ? "var(--coral)"
+            : canConvert
+              ? "var(--ink)"
+              : "var(--ink-mute)",
+          color: "#fff",
+          border: "1px solid rgba(255,255,255,0.18)",
+          boxShadow: "0 4px 18px rgba(15, 14, 12, 0.18)",
+        }}
+      >
+        {isRunning ? (
+          <>
+            <span className="pulse-dot" style={{ background: "#fff" }} />
+            {t("toolbar.stop")}
+          </>
+        ) : (
+          <>
+            <span aria-hidden>⚡</span>
+            {t("convertChip.label")}
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/editor-pane.tsx
+++ b/src/components/editor-pane.tsx
@@ -10,6 +10,7 @@ import { UploadDropzone } from "./upload-dropzone";
 import { DraftsMenu } from "./drafts-menu";
 import { SamplesGallery } from "./samples-gallery";
 import { FormatsGallery } from "./formats-gallery";
+import { AiPromptBar } from "./ai-prompt-bar";
 
 const TAB_KEY: Record<"text" | "upload" | "formats" | "samples", DictKey> = {
   text: "editor.tab.text",
@@ -91,27 +92,30 @@ export function EditorPane() {
 
       <div className="relative flex-1 overflow-hidden">
         {tab === "text" && (
-          <>
-            {!hydrated && (
-              <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
-                <div className="text-[11px] text-[var(--ink-faint)]">{t("editor.restoring")}</div>
-              </div>
-            )}
-            <textarea
-              value={hydrated ? content : ""}
-              onChange={(e) => {
-                if (!hydrated) return;
-                setContent(e.target.value);
-                setFilename(undefined);
-                const fmt = detectFormat(e.target.value);
-                if (fmt !== format) setFormat(fmt);
-              }}
-              placeholder={t("editor.placeholder")}
-              className="block h-full w-full resize-none border-0 bg-transparent p-5 font-[family-name:var(--font-mono)] text-[13px] leading-relaxed text-[var(--ink)] outline-none placeholder:text-[var(--ink-faint)]"
-              spellCheck={false}
-              disabled={!hydrated}
-            />
-          </>
+          <div className="flex h-full flex-col">
+            <div className="relative flex-1 overflow-hidden">
+              {!hydrated && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+                  <div className="text-[11px] text-[var(--ink-faint)]">{t("editor.restoring")}</div>
+                </div>
+              )}
+              <textarea
+                value={hydrated ? content : ""}
+                onChange={(e) => {
+                  if (!hydrated) return;
+                  setContent(e.target.value);
+                  setFilename(undefined);
+                  const fmt = detectFormat(e.target.value);
+                  if (fmt !== format) setFormat(fmt);
+                }}
+                placeholder={t("editor.placeholder")}
+                className="block h-full w-full resize-none border-0 bg-transparent p-5 font-[family-name:var(--font-mono)] text-[13px] leading-relaxed text-[var(--ink)] outline-none placeholder:text-[var(--ink-faint)]"
+                spellCheck={false}
+                disabled={!hydrated}
+              />
+            </div>
+            <AiPromptBar />
+          </div>
         )}
         {tab === "upload" && (
           <div className="h-full p-4">

--- a/src/components/preview-pane.tsx
+++ b/src/components/preview-pane.tsx
@@ -48,7 +48,36 @@ export function PreviewPane({
   const log = useStore((s) => selectActiveTask(s)?.log ?? EMPTY_LOG);
   const stats = useStore((s) => selectActiveTask(s)?.stats ?? EMPTY_STATS);
   const activeTaskId = useStore((s) => s.activeTaskId);
+  const templateId = useStore((s) => selectActiveTask(s)?.templateId);
   const setHtmlFor = useStore((s) => s.setHtmlFor);
+
+  // Template example HTML — fetched lazily when no task.html exists yet, so
+  // switching templates in the picker shows that template's pre-shipped
+  // `example.html` immediately, without burning agent tokens. Cleared as soon
+  // as Convert produces real html, never written to task state.
+  const [templateExample, setTemplateExample] = useState<string>("");
+  useEffect(() => {
+    // only fetch when there's no real output yet AND the run is idle
+    if (html || status === "running") {
+      setTemplateExample("");
+      return;
+    }
+    if (!templateId) return;
+    let cancelled = false;
+    fetch(`/api/templates/${encodeURIComponent(templateId)}/example`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const exampleHtml = (data?.html ?? "") as string;
+        setTemplateExample(exampleHtml);
+      })
+      .catch(() => {
+        if (!cancelled) setTemplateExample("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [templateId, html, status]);
   const [tab, setTab] = useState<PreviewTab>("preview");
   const localRef = useRef<HTMLIFrameElement | null>(null);
   const codeRef = useRef<HTMLTextAreaElement | null>(null);
@@ -97,8 +126,14 @@ export function PreviewPane({
     return () => window.removeEventListener("keydown", onKey);
   }, [tab, toggleFullscreen]);
 
+  // Effective html for this render = real task output if any, else the
+  // template example fetched above. Downstream (deck detection, debounce,
+  // iframe srcDoc) treats both identically — the only difference is provenance.
+  const effectiveHtml = html || templateExample;
+  const isPreviewingTemplate = !html && !!templateExample;
+
   // Detect deck off the cleaned (un-fenced) html — extract once for reuse.
-  const cleaned = useMemo(() => extractHtml(html), [html]);
+  const cleaned = useMemo(() => extractHtml(effectiveHtml), [effectiveHtml]);
   const deckMode = useMemo(() => isDeck(cleaned), [cleaned]);
 
   // First time we see a deck, auto-promote the user to the Deck tab so the
@@ -118,15 +153,15 @@ export function PreviewPane({
 
   // Debounce srcDoc updates to ~3 fps during streaming so the iframe
   // doesn't reload on every delta. Last value always commits when status changes.
-  const [debouncedHtml, setDebouncedHtml] = useState(html);
+  const [debouncedHtml, setDebouncedHtml] = useState(effectiveHtml);
   useEffect(() => {
     if (status !== "running") {
-      setDebouncedHtml(html);
+      setDebouncedHtml(effectiveHtml);
       return;
     }
-    const id = setTimeout(() => setDebouncedHtml(html), 320);
+    const id = setTimeout(() => setDebouncedHtml(effectiveHtml), 320);
     return () => clearTimeout(id);
-  }, [html, status]);
+  }, [effectiveHtml, status]);
   const display = useMemo(() => previewHtml(debouncedHtml), [debouncedHtml]);
 
   useEffect(() => {
@@ -161,8 +196,9 @@ export function PreviewPane({
 
   // Present button is meaningful for Preview / Source / Log. The Deck tab has
   // its own Present button inside DeckViewer; suppress ours there to avoid
-  // two competing fullscreens.
-  const canPresent = tab !== "deck" && (tab !== "preview" || !!html);
+  // two competing fullscreens. Template-only previews count as "has html" for
+  // the Present button so users can preview at full size without converting.
+  const canPresent = tab !== "deck" && (tab !== "preview" || !!effectiveHtml);
 
   return (
     <div
@@ -250,17 +286,32 @@ export function PreviewPane({
       <div className="relative flex-1 overflow-hidden">
         {tab === "preview" && (
           <>
-            {!html && <PreviewPlaceholder status={status} />}
-            {html && (
-              <iframe
-                key={refreshKey}
-                ref={localRef}
-                title="preview"
-                srcDoc={display}
-                sandbox="allow-scripts allow-same-origin"
-                className="h-full w-full"
-                style={{ background: "#fff" }}
-              />
+            {!effectiveHtml && <PreviewPlaceholder status={status} />}
+            {effectiveHtml && (
+              <>
+                <iframe
+                  key={refreshKey}
+                  ref={localRef}
+                  title="preview"
+                  srcDoc={display}
+                  sandbox="allow-scripts allow-same-origin"
+                  className="h-full w-full"
+                  style={{ background: "#fff" }}
+                />
+                {isPreviewingTemplate && (
+                  <div
+                    className="pointer-events-none absolute left-3 top-3 rounded-full px-2.5 py-1 text-[10.5px] font-medium tracking-wide"
+                    style={{
+                      background: "rgba(15, 14, 12, 0.78)",
+                      color: "#f3efe6",
+                      backdropFilter: "blur(6px)",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    模板预览 · TEMPLATE EXAMPLE
+                  </div>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/components/upload-dropzone.tsx
+++ b/src/components/upload-dropzone.tsx
@@ -11,6 +11,7 @@ export function UploadDropzone() {
   const setContent = useStore((s) => s.setContent);
   const setFormat = useStore((s) => s.setFormat);
   const setFilename = useStore((s) => s.setFilename);
+  const addAsset = useStore((s) => s.addAsset);
   const pushLog = useStore((s) => s.pushLog);
   const t = useT();
 
@@ -20,7 +21,16 @@ export function UploadDropzone() {
       const file = files[0];
       try {
         const parsed = await parseFile(file);
-        setContent(parsed.text);
+        // For images, replace the inline base64 data URL in `text` with a
+        // short `asset:<id>` placeholder so the textarea stays readable.
+        // The real bytes live in task.assets and are inlined back at
+        // Convert time.
+        let bodyText = parsed.text;
+        if (parsed.format === "image" && parsed.dataUrl) {
+          const id = addAsset(parsed.dataUrl);
+          bodyText = `![${parsed.filename}](asset:${id})`;
+        }
+        setContent(bodyText);
         setFormat(parsed.format);
         setFilename(parsed.filename);
         pushLog({
@@ -34,7 +44,7 @@ export function UploadDropzone() {
         });
       }
     },
-    [setContent, setFormat, setFilename, pushLog, t],
+    [setContent, setFormat, setFilename, addAsset, pushLog, t],
   );
 
   return (

--- a/src/lib/agents/argv.ts
+++ b/src/lib/agents/argv.ts
@@ -125,10 +125,35 @@ export type AgentParse =
   | { kind: "noise" };
 
 /**
- * Parse a single line of agent stdout. Returns either a text delta, a metadata
- * event (model/usage/cost/etc), or noise.
+ * Cross-line state that the parser carries between calls. Currently used to
+ * dedupe text deltas: when an agent emits both fine-grained `stream_event`
+ * `text_delta` blocks AND a final `assistant` message containing the same
+ * text concatenated, we keep the streamed tokens and skip the assistant
+ * message body. Without this dedupe, every Claude/Cursor/Gemini/Qoder run
+ * with `--include-partial-messages` (or the equivalent) writes its output
+ * twice.
+ */
+export type ParseState = { sawStreamEventText?: boolean };
+
+/**
+ * Build a stateful per-invocation parser. Feed every stdout line through the
+ * returned function — it carries the cross-line state needed for dedupe.
+ */
+export function makeParser(agent: string): (line: string) => AgentParse[] {
+  const state: ParseState = {};
+  return (line: string) => parseLineWithState(agent, line, state);
+}
+
+/**
+ * Parse a single line of agent stdout. Stateless wrapper kept for callers
+ * that only need one-shot parsing (e.g. `extractTextFromLine`). Streaming
+ * callers should use `makeParser` so dedupe state survives across lines.
  */
 export function parseLine(agent: string, line: string): AgentParse[] {
+  return parseLineWithState(agent, line, {});
+}
+
+function parseLineWithState(agent: string, line: string, state: ParseState): AgentParse[] {
   const trimmed = line.trim();
   if (!trimmed) return [];
 
@@ -159,24 +184,27 @@ export function parseLine(agent: string, line: string): AgentParse[] {
     if (obj.type === "stream_event" && obj.event && typeof obj.event === "object") {
       const ev = obj.event as { type?: string; delta?: { type?: string; text?: string; thinking?: string } };
       if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && typeof ev.delta.text === "string") {
+        state.sawStreamEventText = true;
         out.push({ kind: "delta", text: ev.delta.text });
       } else if (ev.type === "content_block_delta" && ev.delta?.type === "thinking_delta") {
         out.push({ kind: "meta", key: "thinking", value: ev.delta.thinking });
       }
     }
-    // Full assistant messages — only used as fallback when stream events absent (i.e. no --include-partial-messages on old claude)
+    // Full assistant messages — fallback only when stream_event text deltas
+    // were absent (e.g. older claude without --include-partial-messages).
     if (obj.type === "assistant" && obj.message && typeof obj.message === "object") {
       const msg = obj.message as {
         content?: Array<{ type?: string; text?: string }>;
         usage?: Record<string, number>;
         model?: string;
       };
-      // Only emit text if no stream_event blocks observed (the caller dedupes)
-      const text = (msg.content ?? [])
-        .filter((c) => c?.type === "text" && typeof c.text === "string")
-        .map((c) => c.text!)
-        .join("");
-      if (text) out.push({ kind: "delta", text });
+      if (!state.sawStreamEventText) {
+        const text = (msg.content ?? [])
+          .filter((c) => c?.type === "text" && typeof c.text === "string")
+          .map((c) => c.text!)
+          .join("");
+        if (text) out.push({ kind: "delta", text });
+      }
       if (msg.usage) out.push({ kind: "meta", key: "usage_partial", value: msg.usage });
     }
     if (obj.type === "result") {
@@ -215,10 +243,11 @@ export function parseLine(agent: string, line: string): AgentParse[] {
     if (obj.type === "stream_event" && obj.event && typeof obj.event === "object") {
       const ev = obj.event as { type?: string; delta?: { type?: string; text?: string } };
       if (ev.delta?.type === "text_delta" && typeof ev.delta.text === "string") {
+        state.sawStreamEventText = true;
         out.push({ kind: "delta", text: ev.delta.text });
       }
     }
-    if (obj.type === "assistant" && obj.message && typeof obj.message === "object") {
+    if (obj.type === "assistant" && obj.message && typeof obj.message === "object" && !state.sawStreamEventText) {
       const msg = obj.message as { content?: Array<{ type?: string; text?: string }> };
       const text = (msg.content ?? [])
         .filter((c) => c?.type === "text" && typeof c.text === "string")
@@ -226,7 +255,13 @@ export function parseLine(agent: string, line: string): AgentParse[] {
         .join("");
       if (text) out.push({ kind: "delta", text });
     }
-    if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text as string });
+    // Bare `text` field — only honor it when we haven't already emitted a
+    // streamed delta or an assistant body, otherwise it duplicates the same
+    // payload (cursor-agent / gemini both ship this redundancy on some
+    // versions).
+    if (typeof obj.text === "string" && !state.sawStreamEventText && obj.type !== "assistant") {
+      out.push({ kind: "delta", text: obj.text as string });
+    }
   }
 
   if (agent === "copilot") {
@@ -253,10 +288,11 @@ export function parseLine(agent: string, line: string): AgentParse[] {
     if (obj.type === "stream_event" && obj.event && typeof obj.event === "object") {
       const ev = obj.event as { type?: string; delta?: { type?: string; text?: string } };
       if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && typeof ev.delta.text === "string") {
+        state.sawStreamEventText = true;
         out.push({ kind: "delta", text: ev.delta.text });
       }
     }
-    if (obj.type === "assistant" && obj.message && typeof obj.message === "object") {
+    if (obj.type === "assistant" && obj.message && typeof obj.message === "object" && !state.sawStreamEventText) {
       const msg = obj.message as { content?: Array<{ type?: string; text?: string }> };
       const text = (msg.content ?? [])
         .filter((c) => c?.type === "text" && typeof c.text === "string")
@@ -268,7 +304,9 @@ export function parseLine(agent: string, line: string): AgentParse[] {
       if (obj.usage) out.push({ kind: "meta", key: "usage", value: obj.usage });
       if (typeof obj.duration_ms === "number") out.push({ kind: "meta", key: "duration_ms", value: obj.duration_ms });
     }
-    if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
+    if (typeof obj.text === "string" && !state.sawStreamEventText && obj.type !== "assistant") {
+      out.push({ kind: "delta", text: obj.text });
+    }
   }
 
   return out;

--- a/src/lib/agents/invoke.ts
+++ b/src/lib/agents/invoke.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { resolveOnPath, AGENTS } from "./detect";
-import { buildArgv, envFor, parseLine, UnsupportedAgentProtocolError } from "./argv";
+import { buildArgv, envFor, makeParser, UnsupportedAgentProtocolError } from "./argv";
 
 export type InvokeOpts = {
   agent: string;
@@ -103,6 +103,10 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         child.stdin.end();
       } catch {}
 
+      // One parser per spawn so cross-line dedupe state (sawStreamEventText)
+      // is scoped to this single invocation and doesn't leak across runs.
+      const parse = makeParser(opts.agent);
+
       let stdoutBuf = "";
       child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk: string) => {
@@ -113,7 +117,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           const line = stdoutBuf.slice(0, nl);
           stdoutBuf = stdoutBuf.slice(nl + 1);
           if (!line) continue;
-          for (const part of parseLine(opts.agent, line)) {
+          for (const part of parse(line)) {
             if (part.kind === "delta") safeEnqueue({ type: "delta", text: part.text });
             else if (part.kind === "meta") safeEnqueue({ type: "meta", key: part.key, value: part.value });
             else safeEnqueue({ type: "raw", text: line.slice(0, 240) });
@@ -133,7 +137,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
 
       child.on("close", (code) => {
         if (stdoutBuf) {
-          for (const part of parseLine(opts.agent, stdoutBuf)) {
+          for (const part of parse(stdoutBuf)) {
             if (part.kind === "delta") safeEnqueue({ type: "delta", text: part.text });
             else if (part.kind === "meta") safeEnqueue({ type: "meta", key: part.key, value: part.value });
           }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -27,6 +27,11 @@ export interface Dict {
   "toolbar.shortcutHint": string;
   "convertChip.label": string;
   "convertChip.tooltip": string;
+  "aiPrompt.placeholder": string;
+  "aiPrompt.submit": string;
+  "aiPrompt.stop": string;
+  "aiPrompt.needAgent": string;
+  "aiPrompt.hint": string;
 
   // Layout mode toggle
   "layout.aria.group": string;
@@ -295,6 +300,11 @@ const en: Dict = {
   "toolbar.shortcutHint": "⌘+Enter to convert",
   "convertChip.label": "Generate HTML",
   "convertChip.tooltip": "Generate HTML from the markdown on the left",
+  "aiPrompt.placeholder": "Ask AI to write markdown — \"draft a tweet about X\", \"summarize the above\"…",
+  "aiPrompt.submit": "✨ Draft",
+  "aiPrompt.stop": "◼ Stop",
+  "aiPrompt.needAgent": "Pick an agent first",
+  "aiPrompt.hint": "Streams below your existing content. ⌘+Enter to send.",
 
   "layout.aria.group": "Workspace layout",
   "layout.label.editor": "Editor only",
@@ -555,6 +565,11 @@ const zhCN: Dict = {
   "toolbar.convert": "⚡ 转换为 HTML",
   "convertChip.label": "生成 HTML",
   "convertChip.tooltip": "把左侧 markdown 内容转成 HTML",
+  "aiPrompt.placeholder": "让 AI 帮你写 markdown — 「写一条关于 X 的推文」「总结上面这段」…",
+  "aiPrompt.submit": "✨ 生成",
+  "aiPrompt.stop": "◼ 停止",
+  "aiPrompt.needAgent": "先在右上角选个 agent",
+  "aiPrompt.hint": "结果会追加到上方现有内容下方。⌘+Enter 发送。",
   "toolbar.firstSelectAgent": "先选择 agent",
   "toolbar.unsupportedProtocol": "ACP / pi-rpc 协议暂未接入, 请换其他 agent",
   "toolbar.enterContent": "输入或上传内容",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -25,6 +25,8 @@ export interface Dict {
   "toolbar.unsupportedProtocol": string;
   "toolbar.enterContent": string;
   "toolbar.shortcutHint": string;
+  "convertChip.label": string;
+  "convertChip.tooltip": string;
 
   // Layout mode toggle
   "layout.aria.group": string;
@@ -291,6 +293,8 @@ const en: Dict = {
   "toolbar.unsupportedProtocol": "ACP / pi-rpc not wired yet — pick another agent",
   "toolbar.enterContent": "Type or upload content",
   "toolbar.shortcutHint": "⌘+Enter to convert",
+  "convertChip.label": "Generate HTML",
+  "convertChip.tooltip": "Generate HTML from the markdown on the left",
 
   "layout.aria.group": "Workspace layout",
   "layout.label.editor": "Editor only",
@@ -549,6 +553,8 @@ const zhCN: Dict = {
   "toolbar.settings": "设置",
   "toolbar.stop": "◼ 停止",
   "toolbar.convert": "⚡ 转换为 HTML",
+  "convertChip.label": "生成 HTML",
+  "convertChip.tooltip": "把左侧 markdown 内容转成 HTML",
   "toolbar.firstSelectAgent": "先选择 agent",
   "toolbar.unsupportedProtocol": "ACP / pi-rpc 协议暂未接入, 请换其他 agent",
   "toolbar.enterContent": "输入或上传内容",

--- a/src/lib/parsers/file.ts
+++ b/src/lib/parsers/file.ts
@@ -49,7 +49,10 @@ export async function parseFile(file: File): Promise<FileParseResult> {
       r.onerror = reject;
       r.readAsDataURL(file);
     });
-    // For images we describe and embed; ai will be told to render the image inline
+    // Caller (upload-dropzone) is expected to register the dataUrl as an
+    // asset and substitute an `asset:<id>` token into `text` before writing
+    // it to the editor — keeping the textarea readable. We still return the
+    // raw inline form here as a fallback for legacy callers.
     return {
       filename: file.name,
       format: "image",

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -77,6 +77,13 @@ export type Task = {
   baseHtml?: string;
   /** id of the source sample (if any), so the gallery can mark it loaded */
   sampleId?: string;
+  /**
+   * Pasted/uploaded image data URLs, keyed by the short `asset:<id>` token
+   * shown in the editor textarea. Keeps the textarea readable while
+   * preserving the real bytes for Convert. Resolved back to inline data URLs
+   * in `use-convert.ts` before the prompt is shipped to the agent.
+   */
+  assets?: Record<string, string>;
   // meta
   createdAt: number;
   updatedAt: number;
@@ -181,6 +188,12 @@ type State = {
   setFormat: (f: string) => void;
   setFilename: (f?: string) => void;
   setSelectedTemplate: (id: string) => void;
+  /**
+   * Add an image (or other binary) asset to the active task and return the
+   * `asset:<id>` placeholder token to insert into the textarea. The data URL
+   * is kept off-textarea so editing stays readable.
+   */
+  addAsset: (dataUrl: string) => string;
 
   // active-task convert-state setters (used by ad-hoc callers, e.g. drafts-menu)
   pushLog: (entry: Omit<LogEntry, "ts">) => void;
@@ -306,6 +319,16 @@ export const useStore = create<State>()(
         set((st) => ({ tasks: patchTask(st.tasks, st.activeTaskId, { filename: f }) })),
       setSelectedTemplate: (id) =>
         set((st) => ({ tasks: patchTask(st.tasks, st.activeTaskId, { templateId: id }) })),
+
+      addAsset: (dataUrl: string) => {
+        const id = `a_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+        set((st) => ({
+          tasks: patchTask(st.tasks, st.activeTaskId, (t) => ({
+            assets: { ...(t.assets ?? {}), [id]: dataUrl },
+          })),
+        }));
+        return id;
+      },
 
       pushLog: (entry) =>
         set((st) => ({

--- a/src/lib/use-convert.ts
+++ b/src/lib/use-convert.ts
@@ -44,7 +44,16 @@ export function useConvert() {
       const startedAt = Date.now();
       store.patchStatsFor(taskId, { startedAt });
 
-      const summary = summarizeForAgent(req.content);
+      // Inline `asset:<id>` placeholders (created by upload-dropzone for
+      // images) back into real `data:image/...` URLs before the agent
+      // sees the prompt. Editor stays readable; agent gets the bytes.
+      const taskWithAssets = store.tasks.find((t) => t.id === taskId);
+      const assets = taskWithAssets?.assets ?? {};
+      const inlinedContent = Object.keys(assets).length
+        ? req.content.replace(/asset:([a-z0-9_]+)/gi, (m, id) => assets[id] ?? m)
+        : req.content;
+
+      const summary = summarizeForAgent(inlinedContent);
       const enrichedContent =
         summary.preview && summary.format !== "markdown" && summary.format !== "html" && summary.format !== "text"
           ? `${summary.preview}\n\n--- 原始内容 ---\n${summary.raw}`

--- a/src/lib/use-draft.ts
+++ b/src/lib/use-draft.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useStore } from "./store";
+
+type DraftReq = {
+  instruction: string;
+  context?: string;
+};
+
+type DraftStatus = "idle" | "running" | "done" | "error";
+
+/**
+ * Streams a markdown draft from the selected coding agent and appends it
+ * to the active task's textarea content as it arrives. Mirrors the SSE
+ * conventions of `useConvert()` (start / delta / meta / done events) but
+ * targets `task.content` instead of `task.html` and uses `/api/draft`,
+ * which prompts the agent for plain markdown — never HTML.
+ */
+export function useDraft() {
+  const [status, setStatus] = useState<DraftStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const ctlRef = useRef<AbortController | null>(null);
+  // Marker we add to task.content right before streaming starts so we can
+  // keep appending exactly to that point even if the user types elsewhere
+  // mid-stream. We swap in a non-printing zero-width sentinel.
+  const insertOffsetRef = useRef<number>(0);
+
+  const cancel = useCallback(() => {
+    ctlRef.current?.abort();
+    ctlRef.current = null;
+  }, []);
+
+  const run = useCallback(async (req: DraftReq) => {
+    cancel();
+    const store = useStore.getState();
+    const agent = store.selectedAgent;
+    if (!agent) {
+      setStatus("error");
+      setError("先在右上角选择一个 agent");
+      return;
+    }
+    const taskId = store.activeTaskId;
+    const agentModels = store.agentModels;
+    const model =
+      agentModels[agent] && agentModels[agent] !== "default"
+        ? agentModels[agent]
+        : undefined;
+
+    const ctl = new AbortController();
+    ctlRef.current = ctl;
+    setStatus("running");
+    setError(null);
+
+    // Snapshot insertion point: end of current content, with a separating
+    // blank line if the user already has content. We append from here.
+    const before = store.tasks.find((t) => t.id === taskId)?.content ?? "";
+    const sep = before.length > 0 && !before.endsWith("\n\n") ? (before.endsWith("\n") ? "\n" : "\n\n") : "";
+    const baseLen = before.length + sep.length;
+    insertOffsetRef.current = baseLen;
+    if (sep) store.setContent(before + sep);
+
+    try {
+      const res = await fetch("/api/draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent,
+          instruction: req.instruction,
+          context: req.context ?? before,
+          ...(model ? { model } : {}),
+        }),
+        signal: ctl.signal,
+      });
+      if (!res.ok || !res.body) {
+        const text = await res.text().catch(() => res.statusText);
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      let lastEvent = "";
+      let appended = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+
+        let blank: number;
+        while ((blank = buf.indexOf("\n\n")) !== -1) {
+          const block = buf.slice(0, blank);
+          buf = buf.slice(blank + 2);
+          const lines = block.split("\n");
+          let event = lastEvent;
+          const dataLines: string[] = [];
+          for (const l of lines) {
+            if (l.startsWith("event:")) event = l.slice(6).trim();
+            else if (l.startsWith("data:")) dataLines.push(l.slice(5).trim());
+          }
+          lastEvent = event;
+          if (!dataLines.length) continue;
+          let data: unknown;
+          try {
+            data = JSON.parse(dataLines.join("\n"));
+          } catch {
+            continue;
+          }
+          if (event === "delta") {
+            const d = data as { text?: string };
+            if (typeof d.text === "string") {
+              appended += d.text;
+              const current = useStore.getState().tasks.find((t) => t.id === taskId)?.content ?? "";
+              // Splice at the recorded base offset; user can still edit
+              // outside the streamed range without losing in-flight tokens.
+              const head = current.slice(0, insertOffsetRef.current);
+              const tail = current.slice(insertOffsetRef.current + appended.length - d.text.length);
+              useStore.getState().setContent(head + appended + tail);
+            }
+          } else if (event === "error") {
+            const d = data as { message?: string };
+            throw new Error(d.message ?? "draft error");
+          }
+        }
+      }
+      setStatus("done");
+    } catch (err) {
+      if ((err as Error)?.name === "AbortError") {
+        setStatus("idle");
+        return;
+      }
+      setStatus("error");
+      setError((err as Error)?.message ?? String(err));
+    } finally {
+      if (ctlRef.current === ctl) ctlRef.current = null;
+    }
+  }, [cancel]);
+
+  return { run, cancel, status, error };
+}


### PR DESCRIPTION
## Summary

Four editor UX fixes plus a fifth one that fell out of verifying #4. Each is a separate commit so review can stop at any point.

| # | Fix | Verified |
|---|---|---|
| 1 | Template-switch preview | ✅ live |
| 2 | Floating "Generate HTML" chip | ✅ live |
| 3 | Image upload no longer dumps base64 into the textarea | ✅ live |
| 4 | AI prompt bar streams markdown into the editor | ✅ live (real Claude / Haiku run) |
| 5 | Dedupe stream-json text deltas across agents | ✅ live (uncovered while verifying #4) |

---

### 1. `feat(preview): show template example.html on template switch`

Before: clicking a template in the picker did nothing visible until the user remembered to hit ⚡ Convert.

After: when the active task has no real Convert output yet (idle, empty html), `PreviewPane` fetches the selected template's pre-shipped example via the existing `/api/templates/[id]/example` route and renders it. A small `模板预览 · TEMPLATE EXAMPLE` badge in the iframe corner flags it as illustrative.

Stored in component-local state, never on the task — as soon as Convert produces real html, the example is dropped. Zero AI tokens spent on previews.

### 2. `feat(ui): floating "Generate HTML" chip on the editor / preview divider`

Users editing markdown couldn't tell they had to travel back up to the toolbar to trigger Convert.

New `<ConvertChip />` pinned to the divider (vertically centered, only in split layout — single-pane modes have no divider). Mirrors toolbar state (running → Stop variant, disabled on no agent / no content / unsupported protocol) and shares the same `useConvert()` hook. The toolbar button and ⌘+Enter shortcut stay; this is additive.

### 3. `feat(editor): collapse uploaded image data URLs into asset placeholders`

Before: uploading a 30 KB PNG dumped a 40 000-character `data:image/png;base64,…` blob into the textarea, pushing all surrounding markdown thousands of lines off-screen.

After: `upload-dropzone` registers the data URL as a task asset and writes a short `![filename](asset:<id>)` placeholder into the textarea. The full data URL lives in `task.assets` and is inlined back into the prompt at Convert time, so the agent still gets the real bytes.

Verified end-to-end: 30 KB PNG upload → textarea 41 chars (placeholder only), `task.assets[id]` = 40 KB data URL, persisted in localStorage.

### 4. `feat(editor): AI prompt bar — stream markdown drafts into the textarea`

A sticky one-line input pinned to the bottom of the editor's Text tab. User types a natural-language instruction ("write a tweet about X"); the selected agent streams a markdown draft that's appended below existing content.

- New `/api/draft` SSE route — reuses `invokeAgent`, prompts agent for plain markdown (no fences, no prefatory phrases, no fabricated data, respects existing language)
- New `useDraft()` hook — splices delta tokens at a recorded base offset so user edits elsewhere during streaming don't clobber in-flight tokens
- New `<AiPromptBar />` — input + ✨ Draft / ◼ Stop pill, error line on failure
- `editor-pane.tsx` Text tab restructured into a flex column so the bar pins to the bottom

End-to-end run against a live `claude` CLI (Haiku) confirmed streaming, splicing, and the ◼ Stop interrupt all work. The first run also surfaced fix #5 below — the SSE pipeline itself was correct, the parser underneath was emitting every token twice.

### 5. `fix(agents): dedupe stream-json text deltas across stream_event + assistant message`

Claude / Cursor Agent / Gemini / Qoder all emit two redundant text payloads when run with `--include-partial-messages` (or equivalent): a stream of fine-grained `stream_event` `content_block_delta` `text_delta` blocks, then a final `assistant` message whose `content[].text` is the same payload concatenated. The parser was emitting both as `kind: "delta"`, so every streamed token landed in the consumer twice.

Visible symptom: AI prompt bar (#4 above) wrote the same markdown into the textarea twice in a row. The Convert path had the same bug — duplicated HTML was masked by iframe rendering, but `task.html` (and Export / Copy output) was actually doubled.

Fix: introduce `makeParser(agent)` — a per-invocation factory carrying a small `ParseState` with a `sawStreamEventText` flag across lines. Each agent branch sets the flag when emitting a streamed text delta and skips the assistant message body when set (still emits usage / model metadata). `parseLine` is kept as a stateless one-shot wrapper for callers like `extractTextFromLine`. `invoke.ts` builds one parser per spawn so dedupe state is scoped to a single invocation and never leaks across runs.

Verified with curl against `/api/draft` (claude/haiku):

| | delta count | joined chars | first half == second half |
|---|---|---|---|
| Before | 17 | 116 | **true** (mirrored) |
| After  | 20 |  64 | false |

UI re-run after fix: textarea contains the three-bullet list exactly once (212 chars). `usage_partial` meta still arrives — only the duplicated text body is suppressed.

---

## Test plan

- [ ] In split layout, click any template in the picker with an empty editor — preview pane should render that template's `example.html` with a `模板预览` badge within ~50ms (no Convert needed)
- [ ] Switch to a deck-category template — preview should auto-promote to the Deck tab and show slide thumbnails
- [ ] Add content to the editor, click Convert — once HTML streams in, the template-preview badge disappears and real output renders
- [ ] In split mode, the "⚡ Generate HTML" chip should sit centered on the divider; in editor-only / preview-only it should disappear
- [ ] Disabled chip tooltip shows correct reason: pick agent / paste content / unsupported protocol
- [ ] Upload a PNG (drag-drop or button) — textarea shows `![filename](asset:<id>)`, NOT a base64 blob; reload the page → asset still resolves on Convert
- [ ] Type any instruction in the AI prompt bar with an agent selected, hit ⌘+Enter — markdown should stream into the textarea below your existing content; ◼ Stop button cancels mid-stream
- [ ] Drafted output is **not** duplicated (single copy, no mirrored second half)
- [ ] Convert output is also single-copy — re-run a Convert and inspect Source / Export to confirm `<html>` appears once

## Out of scope

- Migrating existing tasks that already have inline base64 in their content (the textarea keeps the historical blob for those; new uploads are clean)
- Migrating existing tasks whose `task.html` was generated before fix #5 and is therefore doubled — re-run Convert to overwrite
- The two console errors visible in dev (font preload warnings) — unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)