### PR TITLE
fix+feat: chip occlusion + OpenClaw adapter

### DIFF
--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -22,6 +22,7 @@ const SECTIONS: Array<{ id: SectionId; labelKey: DictKey; hintKey: DictKey }> = 
 const PROTOCOL_KEY: Record<AgentInfo["protocol"], { key: DictKey; tone: "ok" | "warn" }> = {
   stdin: { key: "protocol.stdin", tone: "ok" },
   argv: { key: "protocol.argv", tone: "ok" },
+  "argv-message": { key: "protocol.argvMessage", tone: "ok" },
   acp: { key: "protocol.acp", tone: "warn" },
   "pi-rpc": { key: "protocol.piRpc", tone: "warn" },
 };

--- a/src/components/template-picker.tsx
+++ b/src/components/template-picker.tsx
@@ -249,7 +249,7 @@ export function TemplatePicker() {
 
       {open && (
         <div
-          className="absolute left-0 z-30 mt-2 w-[560px] od-fade-in rounded-2xl overflow-hidden flex flex-col"
+          className="absolute left-0 z-40 mt-2 w-[560px] od-fade-in rounded-2xl overflow-hidden flex flex-col"
           style={{
             background: "var(--surface)",
             border: "1px solid var(--line-soft)",
@@ -467,7 +467,7 @@ export function TemplatePicker() {
       {/* hover preview popover — appears next to dropdown when a row with example.html is hovered */}
       {open && hoveredTpl && hoveredTpl.example?.hasHtml && (
         <aside
-          className="absolute z-30 mt-2 od-fade-in flex flex-col rounded-2xl overflow-hidden"
+          className="absolute z-40 mt-2 od-fade-in flex flex-col rounded-2xl overflow-hidden"
           style={{
             left: "calc(560px + 12px)",
             top: 0,

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -47,7 +47,7 @@ export function Toolbar({
 
   return (
     <header
-      className="relative z-20 flex flex-wrap items-center justify-between gap-3 px-5 py-3"
+      className="relative z-40 flex flex-wrap items-center justify-between gap-3 px-5 py-3"
       style={{
         background: "rgba(250, 249, 247, 0.92)",
         borderBottom: "1px solid var(--line-faint)",

--- a/src/components/welcome-modal.tsx
+++ b/src/components/welcome-modal.tsx
@@ -7,6 +7,7 @@ import { useT, type DictKey } from "@/lib/i18n";
 const PROTOCOL_KEY: Record<AgentInfo["protocol"], { key: DictKey; tone: "ok" | "warn" }> = {
   stdin: { key: "protocol.stdin", tone: "ok" },
   argv: { key: "protocol.argv", tone: "ok" },
+  "argv-message": { key: "protocol.argvMessage", tone: "ok" },
   acp: { key: "protocol.acp", tone: "warn" },
   "pi-rpc": { key: "protocol.piRpc", tone: "warn" },
 };

--- a/src/lib/agents/argv.ts
+++ b/src/lib/agents/argv.ts
@@ -3,6 +3,12 @@ export type AgentArgvOpts = {
   cwd?: string;
   /** When the adapter takes the prompt as a positional argv (deepseek). */
   prompt?: string;
+  /**
+   * For openclaw only — pre-resolved agent id (e.g. "main" or "ops") that
+   * gets injected into the argv as `--agent <id>`. invoke.ts is responsible
+   * for resolving this via `resolveOpenclawAgentId` before calling buildArgv.
+   */
+  openclawAgentId?: string;
 };
 
 export class UnsupportedAgentProtocolError extends Error {
@@ -26,6 +32,20 @@ export function buildArgv(agent: string, _opts: AgentArgvOpts = {}): string[] {
         "--include-partial-messages",
         "--permission-mode",
         "bypassPermissions",
+        ...(model ? ["--model", model] : []),
+      ];
+    case "openclaw":
+      // OpenClaw is a multi-channel agent gateway — invocation is
+      //   openclaw agent --local --json --agent <id> [--model <id>]
+      // and the prompt is appended later via `--message <text>` by invoke.ts
+      // (see protocol === "argv-message"). The agent id is resolved at
+      // invocation time by `resolveOpenclawAgentId`.
+      return [
+        "agent",
+        "--local",
+        "--json",
+        "--agent",
+        _opts.openclawAgentId ?? "main",
         ...(model ? ["--model", model] : []),
       ];
     case "codex":

--- a/src/lib/agents/detect.ts
+++ b/src/lib/agents/detect.ts
@@ -5,15 +5,18 @@ import path, { delimiter, join } from "node:path";
 /**
  * Per-agent invocation protocol. Determines what `invokeAgent` does with the
  * prompt and how it parses output:
- *   - "stdin"     : pipe prompt → child stdin, parse stdout via parseLine
- *   - "argv"      : pass prompt as positional argv (deepseek), parse stdout as plain
- *   - "acp"       : ACP JSON-RPC over stdio (hermes/kimi/devin/kiro/kilo/vibe).
- *                   Not implemented in this build — surfaced in detection so the
- *                   user sees install instructions, but invoke emits a clear
- *                   error pointing them to a supported agent.
- *   - "pi-rpc"    : pi's custom JSON-RPC mode. Same status as "acp".
+ *   - "stdin"        : pipe prompt → child stdin, parse stdout via parseLine
+ *   - "argv"         : pass prompt as positional argv (deepseek), parse stdout as plain
+ *   - "argv-message" : prompt goes via `--message <text>` (openclaw); stdout is
+ *                      a single multi-line JSON document (not ndjson), parsed
+ *                      after the child closes.
+ *   - "acp"          : ACP JSON-RPC over stdio (hermes/kimi/devin/kiro/kilo/vibe).
+ *                      Not implemented in this build — surfaced in detection so
+ *                      the user sees install instructions, but invoke emits a
+ *                      clear error pointing them to a supported agent.
+ *   - "pi-rpc"       : pi's custom JSON-RPC mode. Same status as "acp".
  */
-export type AgentProtocol = "stdin" | "argv" | "acp" | "pi-rpc";
+export type AgentProtocol = "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc";
 
 export type ModelOption = { id: string; label: string };
 
@@ -39,13 +42,14 @@ export type AgentDef = {
 
 export const AGENTS: AgentDef[] = [
   // Drop-in fork list (`fallbackBins`) covers CLIs that ship under a different
-  // binary name but speak the exact same argv protocol. Today: openclaude /
-  // openclaw — both are community Claude Code forks (issue #235 in open-design).
+  // binary name but speak the exact same argv protocol. Today: openclaude is
+  // listed as a fallback for Claude Code; OpenClaw is exposed as its own
+  // first-class entry below so users on machines that have both can pick.
   {
     id: "claude",
     label: "Claude Code",
     bin: "claude",
-    fallbackBins: ["openclaude", "openclaw"],
+    fallbackBins: ["openclaude"],
     envOverride: "CLAUDE_BIN",
     vendor: "Anthropic",
     fallbackModels: [
@@ -56,6 +60,27 @@ export const AGENTS: AgentDef[] = [
       { id: "claude-opus-4-7", label: "claude-opus-4-7" },
       { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
       { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
+    ],
+  },
+  {
+    // OpenClaw is a multi-channel agent gateway, not a Claude-CLI fork —
+    // its CLI surface is `openclaw agent --message <text>` and it returns a
+    // single multi-line JSON blob (no streaming). The "argv-message"
+    // protocol covers the prompt-via-flag and post-close JSON parse.
+    id: "openclaw",
+    label: "OpenClaw",
+    bin: "openclaw",
+    envOverride: "OPENCLAW_BIN",
+    vendor: "OpenClaw multi-channel agent gateway",
+    protocol: "argv-message",
+    fallbackModels: [
+      DEFAULT_MODEL,
+      // Models surface as overrides for OpenClaw's routing; the CLI accepts
+      // `--model <provider/model or model id>`. The list mirrors what
+      // OpenClaw's main agent typically routes to (OpenRouter Claude family).
+      { id: "openrouter/anthropic/claude-opus-4.7", label: "Opus 4.7 (OpenRouter)" },
+      { id: "openrouter/anthropic/claude-sonnet-4.6", label: "Sonnet 4.6 (OpenRouter)" },
+      { id: "openrouter/anthropic/claude-haiku-4.5", label: "Haiku 4.5 (OpenRouter)" },
     ],
   },
   {
@@ -296,6 +321,46 @@ function userToolchainDirs(): string[] {
     dirs.push("/opt/homebrew/bin", "/usr/local/bin");
   }
   return dirs;
+}
+
+/**
+ * Probe `<openclaw> agents list` and return the first agent id (typically
+ * "main"). OpenClaw refuses `agent --message` invocations without one of
+ * `--agent`, `--to`, or `--session-id`, so we resolve this once per-process
+ * with a 5-minute TTL cache.
+ *
+ * Falls back to "main" on any error — that is the OpenClaw default agent
+ * name on a fresh install, so it works for most users out of the box.
+ */
+let openclawAgentIdCache: { value: string; expiresAt: number } | null = null;
+export async function resolveOpenclawAgentId(bin: string): Promise<string> {
+  const now = Date.now();
+  if (openclawAgentIdCache && openclawAgentIdCache.expiresAt > now) {
+    return openclawAgentIdCache.value;
+  }
+  let resolved = "main";
+  try {
+    const { spawn } = await import("node:child_process");
+    const out = await new Promise<string>((res, rej) => {
+      const child = spawn(bin, ["agents", "list"], { stdio: ["ignore", "pipe", "pipe"] });
+      let buf = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (c) => (buf += c));
+      child.on("close", () => res(buf));
+      child.on("error", rej);
+      setTimeout(() => {
+        try { child.kill("SIGTERM"); } catch {}
+        rej(new Error("openclaw agents list timed out"));
+      }, 5_000);
+    });
+    // First agent line looks like:  "- main (default)"  or  "- ops"
+    const m = out.match(/^- (\S+)/m);
+    if (m && m[1]) resolved = m[1];
+  } catch {
+    // keep fallback
+  }
+  openclawAgentIdCache = { value: resolved, expiresAt: now + 5 * 60_000 };
+  return resolved;
 }
 
 export function resolveOnPath(bin: string): string | null {

--- a/src/lib/agents/invoke.ts
+++ b/src/lib/agents/invoke.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { resolveOnPath, AGENTS } from "./detect";
+import { resolveOnPath, resolveOpenclawAgentId, AGENTS } from "./detect";
 import { buildArgv, envFor, makeParser, UnsupportedAgentProtocolError } from "./argv";
 
 export type InvokeOpts = {
@@ -36,26 +36,15 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
     );
   }
 
-  let argv: string[];
-  try {
-    argv = buildArgv(opts.agent, { model: opts.model, prompt: opts.prompt });
-  } catch (err) {
-    return errorStream(
-      err instanceof UnsupportedAgentProtocolError
-        ? err.message
-        : err instanceof Error
-          ? err.message
-          : String(err),
-    );
-  }
-  // `protocol: "argv"` adapters (deepseek today) take the prompt as a
-  // trailing positional arg rather than reading from stdin.
-  const promptViaArgv = def.protocol === "argv";
-  if (promptViaArgv) argv = [...argv, opts.prompt];
+  // For openclaw we need an async detection step (resolveOpenclawAgentId)
+  // before buildArgv. Do all of the argv assembly inside the stream's async
+  // start so we can `await` and surface failures as `error` events.
   const env = envFor(opts.agent);
+  const promptViaArgv = def.protocol === "argv";
+  const promptViaMessageFlag = def.protocol === "argv-message";
 
   return new ReadableStream<InvokeEvent>({
-    start(controller) {
+    async start(controller) {
       let closed = false;
       let child: ChildProcessWithoutNullStreams | null = null;
 
@@ -74,6 +63,39 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           controller.close();
         } catch {}
       };
+
+      // Resolve agent-specific argv. For openclaw we first probe `agents
+      // list` to learn the actual agent id (commonly "main") so the CLI's
+      // required `--agent <id>` is satisfied.
+      let argv: string[];
+      try {
+        const argvOpts: Parameters<typeof buildArgv>[1] = {
+          model: opts.model,
+          prompt: opts.prompt,
+        };
+        if (opts.agent === "openclaw") {
+          argvOpts.openclawAgentId = await resolveOpenclawAgentId(bin!);
+        }
+        argv = buildArgv(opts.agent, argvOpts);
+      } catch (err) {
+        safeEnqueue({
+          type: "error",
+          message:
+            err instanceof UnsupportedAgentProtocolError
+              ? err.message
+              : err instanceof Error
+                ? err.message
+                : String(err),
+        });
+        safeClose();
+        return;
+      }
+      // `protocol: "argv"` adapters (deepseek today) take the prompt as a
+      // trailing positional arg rather than reading from stdin.
+      if (promptViaArgv) argv = [...argv, opts.prompt];
+      // `protocol: "argv-message"` (openclaw today) wants the prompt under
+      // an explicit `--message <text>` flag.
+      if (promptViaMessageFlag) argv = [...argv, "--message", opts.prompt];
 
       try {
         child = spawn(bin!, argv, {
@@ -99,7 +121,9 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
 
       child.stdin.on("error", () => {});
       try {
-        if (!promptViaArgv) child.stdin.write(opts.prompt);
+        // stdin-protocol agents read the prompt from stdin; argv / argv-message
+        // agents already have it on the command line.
+        if (!promptViaArgv && !promptViaMessageFlag) child.stdin.write(opts.prompt);
         child.stdin.end();
       } catch {}
 
@@ -112,6 +136,9 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
       child.stdout.on("data", (chunk: string) => {
         if (closed) return;
         stdoutBuf += chunk;
+        // OpenClaw emits one big multi-line JSON document — accumulate and
+        // parse it once on close instead of trying to parse each line.
+        if (opts.agent === "openclaw") return;
         let nl: number;
         while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
           const line = stdoutBuf.slice(0, nl);
@@ -136,7 +163,58 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
       });
 
       child.on("close", (code) => {
-        if (stdoutBuf) {
+        if (opts.agent === "openclaw") {
+          // OpenClaw's `agent --local --json` emits one pretty-printed JSON
+          // document on stdout. The visible reply is at
+          // `data.finalAssistantVisibleText`; usage / model show up in
+          // `data.executionTrace`. Emit the visible text as a single delta.
+          if (stdoutBuf.trim()) {
+            try {
+              const obj = JSON.parse(stdoutBuf) as {
+                payloads?: Array<{ text?: string }>;
+                meta?: {
+                  finalAssistantVisibleText?: string;
+                  finalAssistantRawText?: string;
+                  executionTrace?: { winnerProvider?: string; winnerModel?: string };
+                  completion?: { stopReason?: string };
+                  agentMeta?: { sessionId?: string };
+                };
+              };
+              const text = obj?.meta?.finalAssistantVisibleText
+                ?? obj?.meta?.finalAssistantRawText
+                ?? obj?.payloads?.[0]?.text
+                ?? "";
+              if (text) safeEnqueue({ type: "delta", text });
+              const trace = obj?.meta?.executionTrace;
+              if (trace?.winnerModel) {
+                safeEnqueue({
+                  type: "meta",
+                  key: "model",
+                  value: trace.winnerProvider
+                    ? `${trace.winnerProvider}/${trace.winnerModel}`
+                    : trace.winnerModel,
+                });
+              }
+              if (obj?.meta?.agentMeta?.sessionId) {
+                safeEnqueue({ type: "meta", key: "session", value: obj.meta.agentMeta.sessionId });
+              }
+              if (obj?.meta?.completion?.stopReason) {
+                safeEnqueue({ type: "meta", key: "result", value: obj.meta.completion.stopReason });
+              }
+              if (!text) {
+                safeEnqueue({
+                  type: "error",
+                  message: "OpenClaw returned an empty assistant message",
+                });
+              }
+            } catch (err) {
+              safeEnqueue({
+                type: "error",
+                message: `OpenClaw JSON parse failed: ${err instanceof Error ? err.message : String(err)}`,
+              });
+            }
+          }
+        } else if (stdoutBuf) {
           for (const part of parse(stdoutBuf)) {
             if (part.kind === "delta") safeEnqueue({ type: "delta", text: part.text });
             else if (part.kind === "meta") safeEnqueue({ type: "meta", key: part.key, value: part.value });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -76,6 +76,7 @@ export interface Dict {
   "agent.notInstalled": string;
   "protocol.stdin": string;
   "protocol.argv": string;
+  "protocol.argvMessage": string;
   "protocol.acp": string;
   "protocol.piRpc": string;
 
@@ -346,6 +347,7 @@ const en: Dict = {
   "agent.notInstalled": "Not installed",
   "protocol.stdin": "stdin · stream",
   "protocol.argv": "positional argv",
+  "protocol.argvMessage": "argv · batch JSON",
   "protocol.acp": "ACP JSON-RPC · not wired",
   "protocol.piRpc": "pi-rpc · not wired",
 
@@ -615,6 +617,7 @@ const zhCN: Dict = {
   "agent.notInstalled": "未安装",
   "protocol.stdin": "stdin · stream",
   "protocol.argv": "positional argv",
+  "protocol.argvMessage": "argv · 整段 JSON",
   "protocol.acp": "ACP JSON-RPC · 暂未接入",
   "protocol.piRpc": "pi-rpc · 暂未接入",
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -12,8 +12,8 @@ export type AgentInfo = {
   vendor: string;
   available: boolean;
   path?: string;
-  /** "stdin" | "argv" | "acp" | "pi-rpc" — used by UI to badge unsupported adapters. */
-  protocol: "stdin" | "argv" | "acp" | "pi-rpc";
+  /** UI uses this to badge unsupported / batch adapters. Mirrors AgentProtocol on the server. */
+  protocol: "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc";
   /** Curated model list for the picker. Always begins with `default`. */
   models: ModelOption[];
   /** True for ACP / pi-rpc adapters where Convert returns a friendly error. */


### PR DESCRIPTION
## Summary

Two independent commits, packaged into one PR for review convenience:

1. **`fix(ui)`** — the editor's floating "Generate HTML" chip was rendering on top of the template picker dropdown and its hover preview popover, blocking access to the picker once it was open.
2. **`feat(agents)`** — wire OpenClaw as a first-class agent in Settings so users can route Draft / Convert through OpenClaw's local agent runner instead of Claude Code.

---

### 1. `fix(ui): chip no longer occludes the template picker overlays`

**Symptom**: with the picker open, the chip floated *over* the dropdown / hover preview, so users couldn't click rows that fell behind it (and visually it looked like a layering bug, which it was).

**Root cause**: the toolbar `<header>` is `position: relative; z-20`. That creates a stacking context for everything inside it, including the picker. The picker's own dropdown declared `z-30` and the hover preview declared `z-30`, but those numbers only compared against siblings *within* the header's z-20 context — never against the editor's chip wrapper at `z-30`, which lives outside the header. So the comparison was effectively `header (z-20) vs chip (z-30)` and the chip won.

**Fix**: bump the toolbar `<header>` to `z-40` so its stacking context is above the chip wrapper, and bump the picker dropdown / hover popover to `z-40` to match (so they remain above any other in-page chrome that might share the toolbar's stacking context in the future).

**Verification** (programmatic, with picker + hover preview open):
```js
elementsFromPoint(chipCenterX, chipCenterY)[0]
// before fix: BUTTON (chip)
// after fix : BUTTON inside picker dropdown row
```

### 2. `feat(agents): wire OpenClaw as a first-class agent (argv-message protocol)`

**Why this needed work**: the previous code listed `openclaw` as a `fallbackBin` of Claude Code, on the theory that OpenClaw was a Claude Code drop-in fork. It is not — OpenClaw is a multi-channel agent gateway with its own CLI surface (`openclaw agent --local --json --agent <id> --message <text>`) that:
- Treats Claude's `--output-format stream-json` as an unknown subcommand and refuses to run.
- Does not stream — it returns a single multi-line JSON document on stdout when the child exits.
- Wants the prompt under an explicit `--message <text>` flag, not on stdin.
- Requires a session selector — one of `--agent <id>`, `--to <e164>`, or `--session-id <id>` — even for a one-shot run.

**Solution**: a new `argv-message` protocol that sits alongside `stdin` / `argv`:

| File | Change |
|---|---|
| `detect.ts` | `AgentProtocol` gains `"argv-message"`. New OpenClaw `AgentDef` (independent of Claude Code). New `resolveOpenclawAgentId(bin)` helper with a 5-minute in-process cache that probes `openclaw agents list` to learn the user's first configured agent id (typically `main`). Falls back to `"main"` on any error. Removed `openclaw` from `claude.fallbackBins`. |
| `argv.ts` | `AgentArgvOpts` gains `openclawAgentId`. `buildArgv("openclaw")` emits `agent --local --json --agent <id> [--model <id>]`. |
| `invoke.ts` | `ReadableStream.start` is now `async` so it can `await resolveOpenclawAgentId(bin)` before `buildArgv`. The new `promptViaMessageFlag` branch appends `--message <prompt>` to argv instead of writing to stdin. On child close, the OpenClaw branch `JSON.parse`s the entire stdout buffer and emits one `delta` with `meta.finalAssistantVisibleText` (falling back to `meta.finalAssistantRawText` and `payloads[0].text`), plus `meta` events for `model` / `session` / `result` derived from `meta.executionTrace` and `meta.completion`. |

**UX trade-off**: OpenClaw is non-streaming, so users see a 10–20 s blank period between pressing ✨ Draft / ⚡ Convert and the full reply landing. The ◼ Stop button still kills the spawn cleanly. A "⏳ thinking…" placeholder delta is a possible follow-up, deliberately out of scope here so we can ship the adapter first.

**End-to-end verification** against `/api/draft` (agent=openclaw):
```
event: start  bin=/Users/joey/.npm-global/bin/openclaw
              argv=['agent','--local','--json','--agent','main','--message',<prompt>]
event: delta  text="OpenClaw 是一个开源 AI Agent 运行时，把大模型、本地工具和聊天频道粘成一个真正能干活的智能体。"
event: meta   model=openrouter/anthropic/claude-opus-4.7
event: meta   session=2a96c683-…
event: meta   result=stop
event: done   code=0
```

Settings UI now shows OpenClaw as an installed agent next to Claude Code, with its own model picker (OpenRouter Claude family options).

---

## Test plan

- [ ] Open the template picker; confirm the dropdown and hover preview popover render *above* the floating ⚡ chip
- [ ] In Settings, confirm OpenClaw appears in the "Installed" list with bin path `/<...>/openclaw`
- [ ] Select OpenClaw, type any instruction in ✨ Draft, hit ⌘+Enter — markdown lands in the textarea after ~10–20 s with no error
- [ ] Same with ⚡ Convert: HTML appears in the preview pane after ~10–20 s
- [ ] During an OpenClaw run, ◼ Stop interrupts cleanly (no zombie process)
- [ ] On a machine where the user's OpenClaw agent is named something other than `main`, the adapter still resolves it via `agents list`

## Out of scope

- Streaming experience for OpenClaw (would need OpenClaw to add an ndjson / SSE output mode upstream)
- Multi-agent OpenClaw scenarios (always uses the first agent listed)
- Migrating existing tasks pinned to Claude Code that the user wants to re-run via OpenClaw (manual switch in Settings is the workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)