### PR TITLE
feat(skills): add Product Hunt front-page launch card

### DIFF
--- a/next/src/lib/templates/skills/social-product-hunt-card/SKILL.md
+++ b/next/src/lib/templates/skills/social-product-hunt-card/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: social-product-hunt-card
+zh_name: "Product Hunt 头版报"
+en_name: "Product Hunt Front-Page"
+emoji: "📰"
+description: "把 launch 当天 #1 排成一份周日早报 front page —— Playfair serif + 纸感 + 砖红 accent, 不是橙色 SaaS 卡, 是一份"今日已发生"的头版"
+category: card
+scenario: marketing
+aspect_hint: "1200×630 (OG / Twitter card)"
+tags: ["product-hunt", "launch", "newsprint", "editorial", "front-page", "og-image"]
+example_id: sample-social-product-hunt-card
+example_name: "Product Hunt Times · 头版报 · #1 of the day"
+example_format: markdown
+example_tagline: "纸感 + 巨型 Playfair + 报纸 byline"
+example_desc: "一份'PRODUCT HUNT TIMES'周日头版: 巨型 serif headline + 编辑数字 upvote + hunter byline + 中点分隔 topics"
+---
+
+【模板: Product Hunt 头版报 / Front-Page】
+【意图】把一款产品在 Product Hunt #1 launch 当天的瞬间, 渲染成一份周日早报的 **front page** —— 不是橙色 SaaS 卡片, 不是 dashboard 截图, 而是一份"今日已发生"的报纸头版。用于:
+- 上 PH 当天发推 / 朋友圈 / LinkedIn 的"晒榜"图 (替代千篇一律的 PH 截图)
+- 项目首页 OG 图 / hero 区
+- 产品落地页"as featured on PH"区块
+- 给"我们在 PH 上线"邮件做插图
+
+【设计签名 — 不许跑偏】
+> 灵感不是 producthunt.com 的 UI, 而是 *The New York Times* 周日版头版 + Playfair 编辑封面 + Anthropic 暖纸文档的合体。"Today's launch, framed like front-page news."
+
+【画布】1200×630 OG 比例; 卡片 1120×550 居中, 四周 40px 安全边距; 也支持 1280×720 (按上下文)。
+
+【颜色 — 5 token, 严禁多色】
+- **Paper** `#f3eee2` —— 暖奶油底 (永远不用纯白 `#fff`)。
+- **Ink** `#1f1c17` —— 主文字 (近黑暖灰, 不用纯黑)。
+- **Muted** `#6e6a5d` —— 副文字 / kicker / byline。
+- **Rule** `#d3cdbe` —— 1px hairline (报纸分栏线 / 表格 / 边)。
+- **Accent (砖红橙)** `#c2492c` —— 介于 PH 招牌橙 `#DA552F` 和编辑砖红 `#b85a3a` 之间, 保留 PH 品牌识别但不刺眼; 仅用于: ① 头版报头的 ★ ornament  ② upvote 数字  ③ ▲ 上箭头 glyph  ④ "#1" 数字描边。**禁止**用作大色块 / 背景 / pill 填色。
+
+【字体 — 三族严格分工】
+- **Display 衬线**: `Playfair Display` (英) / `Noto Serif SC` (中); weight 500-700; 仅用于头版 headline (8-10vw) + 大数字。
+- **Lede 斜体衬线**: `Playfair Display Italic`; 仅用于副标题 lede (2 行内)。
+- **Body / kicker / byline 无衬线**: `Inter` 400-600; kicker 11px uppercase letterspacing 0.16em。
+- **数字 / metric / folio**: `JetBrains Mono` 400-600, 启用 `font-feature-settings:'tnum'`。
+- **绝不**: 多种衬线混用; sans 用作 hero headline; 圆体字 (Comic / Quicksand / Nunito 那种)。
+
+【排版规则 — newspaper conventions, 不许变】
+- **顶部 masthead 报头** (高 56px): 左 `★` ornament (砖红, inline SVG) + 报头 wordmark `PRODUCT HUNT TIMES` (Playfair 700, 16px, letter-spacing 0.04em); 中央 `VOL. XII · MAY 14, 2026 · #1 EDITION` (mono uppercase 11px, 灰); 右一颗 PH 猫头 logo (砖红, 22×22 SVG, 用作品牌锚点)。下沿一道 1px Rule + 紧贴一条 4px 粗 Ink 实线 (双线报头, 报纸标准)。
+- **kicker 行** (在 headline 上方): `MAKER OPINION ·· LAUNCH DAY ·· #1 PRODUCT OF THE DAY` (mono 11px uppercase, letterspacing 0.18em, 灰)。`#1` 用 Accent 色, 其余灰。
+- **Hero headline**: 产品名 / 或一句标语 (如 "Markdown is dead. Long live HTML."), Playfair Display 700, `clamp(56px, 8vw, 96px)`, 行高 0.95, 左对齐, 含 1 个 italic 词强调 (e.g. "*HTML*"); 长度上限 60 字符。
+- **Lede**: Playfair Display **Italic** 400, 22-26px, 行高 1.35, 灰 `#3f3a30`, 最多 2 行, 是产品 tagline 的"编辑改写", 不是直接搬。
+- **Hairline rule**: 1px Rule, 全宽; 上下各空 14px。
+- **主体两栏 grid (3:5)**:
+  - **左栏 (statistics block)**: 三段编辑数字, 每段 2 行
+    - 第一段: 巨型 upvote `847` (Playfair 500, 80px, 紧贴 ▲ Accent 三角); 下一行 `UPVOTES · 8 HOURS` (mono uppercase 10px, 灰)
+    - 第二段: `32` (Playfair 500, 44px) + `COMMENTS` (mono uppercase 10px)
+    - 第三段: `12.3K` + `VIEWS`
+    - 三段之间 1px Rule 横向分隔
+  - **右栏 (editorial)**:
+    - kicker `HUNTER'S NOTE` (mono 11px uppercase 灰)
+    - **Pull-quote** (Playfair Italic 400, 19-22px, 行高 1.4): "Just tried it — the SSE streaming into a sandboxed iframe is exactly the missing piece." 含开闭引号字符 “ ” (真引号, 不是 ASCII `"`)
+    - byline em-dash `— @trq212` (Inter 500, 13px, Accent 色)
+    - 一道短 hairline (60px 宽, 不到边)
+    - kicker `FILED UNDER` (mono 11px)
+    - topic 行: `Developer Tools · Open Source · Artificial Intelligence` (Inter 500 14px, 中点 `·` 灰色, topic 名 Ink 色, **不要 pill / 圆角 / bg**)
+- **底部 byline footer 报底** (高 ~56px, bg paper-tint `#ece5d3`, 顶部 1px Rule):
+  - 左侧 `HUNTED BY` (mono uppercase 10px, 灰) + `@nexudotio` (Inter 600 13px, Ink) + 一颗砖红 `★` ornament + `MAKER` (mono uppercase 10px, 描边方框, 内 padding 2/6, 1px Rule 边)
+  - 右侧 `JOINED BY 32 MAKERS · 12 COUNTRIES · LIVE NOW` (mono uppercase 10px, 灰); `LIVE NOW` 加 Accent 色 + 左侧 6×6 blink 圆点。
+
+【纸感 / 质感细节】
+- 卡片 bg 上叠一层 dot pattern: `radial-gradient(circle, rgba(31,28,23,0.06) 1px, transparent 1.4px) 0 0 / 16px 16px`。
+- 卡片本体不要 box-shadow; 只许一层 hairline outline `outline: 1px solid #d3cdbe; outline-offset: -1px`。**禁止** drop-shadow / blur / 多层 shadow。
+- 任何分栏线、边、表格线一律 1px Rule; 唯一例外是报头双线下的 4px Ink 粗线。
+- 不许圆角 ≥ 4px (报头 ornament 例外)。
+- 不许渐变背景。仅允许"叠在 paper 上的 dot pattern"。
+
+【内容生成规则】
+- 产品名 / tagline / topics / hunter / 评论文本 **必须从【用户内容】抽取**; 没给的字段才生成 plausible 占位。
+- 数字: 当天 #1 上 PH 通常 600-1500 upvotes, 25-80 comments, 5-30K views; 不要给 50 也不要给 50K。
+- Headline ≠ tagline。Headline 是"编辑视角的一句话宣言" (e.g. tagline "Your local agent writes HTML" → headline "Markdown is dead. Long live *HTML*."). 含 1 个 italic 强调词。
+- Lede 是 tagline 的扩写, 编辑口吻, **不要营销文案**, **不要感叹号**, **不要"Welcome!"/"Excited to share!"** 这种社媒用语。
+- Pull-quote 来源是 hunter / commenter, 用真引号 “ ”, 一句话, ≤ 100 字符。
+- 严禁 `lorem ipsum`; 严禁 `Product Name` / `Your Tagline Here` / `[Description]` 这种占位。
+
+【代码规则】
+- 单文件 HTML, Tailwind CDN, Google Fonts (Playfair Display + Inter + JetBrains Mono + Noto Serif SC + Noto Sans SC)。
+- 所有 ornament / icon (★ / ▲ / PH 猫头 / blink dot) 内联 SVG, 严禁外链 icon font / 图片。
+- 数字行启用 `font-variant-numeric: tabular-nums`。
+- HTML 第一字符必须是 `<`, 最后必须是 `</html>`; 不要 markdown 围栏 / 解释文字。
+- 不许用 Write / Edit 工具落盘, 直接流式输出。
+
+【设计准则】
+- "Front page, not feed item." 这是周日早报头版, 不是 producthunt.com 的卡片。
+- "Calm brick, not loud orange." Accent 砖红橙仅出现在 ornament / 上箭头 / "#1" / "LIVE NOW" 圆点 ≤ 5 处, 其它一切是 paper / ink / muted 中性。
+- "Editorial weight, not marketing energy." 排版让人感到"这件事是被记录下来的, 不是被吆喝出来的"。
+- "One italic per page." 全页只允许一个 italic 词放在 headline 里, 一个 italic 段落放在 pull-quote, 不要到处斜体。

--- a/next/src/lib/templates/skills/social-product-hunt-card/example.html
+++ b/next/src/lib/templates/skills/social-product-hunt-card/example.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Product Hunt Times · HTML Anything · #1 of the day</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;1,400;1,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Noto+Serif+SC:wght@500;700&family=Noto+Sans+SC:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --paper:  #f3eee2;
+    --tint:   #ece5d3;
+    --ink:    #1f1c17;
+    --muted:  #6e6a5d;
+    --rule:   #d3cdbe;
+    --accent: #c2492c;
+    --display: 'Playfair Display', 'Noto Serif SC', Georgia, serif;
+    --sans:    'Inter', 'Noto Sans SC', system-ui, sans-serif;
+    --mono:    'JetBrains Mono', ui-monospace, monospace;
+  }
+  html, body { background: #e9e2d2; }
+  body {
+    font-family: var(--sans); color: var(--ink); margin: 0;
+    -webkit-font-smoothing: antialiased;
+  }
+  .display { font-family: var(--display); }
+  .mono    { font-family: var(--mono); font-feature-settings: 'tnum'; font-variant-numeric: tabular-nums; }
+  .kicker  { font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); }
+  .paper   {
+    background: var(--paper);
+    background-image: radial-gradient(circle, rgba(31,28,23,0.06) 1px, transparent 1.4px);
+    background-size: 16px 16px;
+  }
+  .rule    { border: 0; border-top: 1px solid var(--rule); }
+  .rule-thick { background: var(--ink); height: 4px; }
+  .em-italic { font-family: var(--display); font-style: italic; font-weight: 500; }
+  .blink-dot { animation: blink 1.6s ease-in-out infinite; }
+  @keyframes blink { 0%, 100% { opacity: 1 } 50% { opacity: .35 } }
+</style>
+</head>
+<body class="min-h-screen flex items-center justify-center p-10">
+
+  <!-- Front-page card -->
+  <article class="paper w-[1120px]" style="outline:1px solid var(--rule); outline-offset:-1px">
+
+    <!-- ① Masthead -->
+    <header class="px-12 pt-7">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2.5">
+          <!-- ★ ornament -->
+          <svg viewBox="0 0 24 24" class="w-[18px] h-[18px]" fill="var(--accent)"><path d="M12 1.5l3.1 7 7.4.7-5.6 5 1.7 7.3L12 17.6 5.4 21.5 7.1 14.2 1.5 9.2l7.4-.7z"/></svg>
+          <span class="display text-[20px] font-bold tracking-tight" style="letter-spacing:0.04em">PRODUCT HUNT TIMES</span>
+          <svg viewBox="0 0 24 24" class="w-[18px] h-[18px]" fill="var(--accent)"><path d="M12 1.5l3.1 7 7.4.7-5.6 5 1.7 7.3L12 17.6 5.4 21.5 7.1 14.2 1.5 9.2l7.4-.7z"/></svg>
+        </div>
+        <div class="mono text-[11px] uppercase" style="color:var(--muted); letter-spacing:0.18em">
+          Vol. XII &nbsp;·&nbsp; May 15, 2026 &nbsp;·&nbsp; #1 Edition
+        </div>
+        <div class="flex items-center gap-2.5">
+          <span class="mono text-[11px] uppercase" style="color:var(--muted); letter-spacing:0.18em">SF · Web · 30¢</span>
+          <!-- PH cat-head -->
+          <svg viewBox="0 0 40 40" class="w-[22px] h-[22px]" fill="var(--accent)">
+            <circle cx="20" cy="20" r="20"/>
+            <path d="M22.5 21H17v6h-3V13h8.5a4 4 0 010 8zm-5.5-3h5.2a1.7 1.7 0 000-3.4H17V18z" fill="var(--paper)"/>
+          </svg>
+        </div>
+      </div>
+      <hr class="rule mt-3" />
+      <div class="rule-thick mt-1.5"></div>
+    </header>
+
+    <!-- ② Hero -->
+    <section class="px-12 pt-5">
+      <!-- kicker -->
+      <div class="kicker">
+        Maker Opinion <span class="opacity-50 mx-1">··</span> Launch Day <span class="opacity-50 mx-1">··</span>
+        <span style="color:var(--accent); font-weight:600">#1 Product of the Day</span>
+      </div>
+
+      <!-- headline -->
+      <h1 class="display mt-2" style="font-size:60px; line-height:0.98; font-weight:700; letter-spacing:-0.01em">
+        Markdown is dead. Long live <span class="em-italic" style="color:var(--accent)">HTML.</span>
+      </h1>
+
+      <!-- lede -->
+      <p class="em-italic mt-3" style="font-size:19px; line-height:1.4; color:#3f3a30; font-weight:400; max-width:920px">
+        After Anthropic stopped shipping internal docs in markdown, a small SF team rebuilt the editor for the agent era — and shipped it to the front page.
+      </p>
+    </section>
+
+    <hr class="rule mx-12 mt-5" />
+
+    <!-- ③ Two-column body grid -->
+    <section class="px-12 mt-5 grid grid-cols-12 gap-8">
+
+      <!-- LEFT · statistics block -->
+      <aside class="col-span-4 flex flex-col">
+        <!-- upvote -->
+        <div class="flex items-baseline gap-3">
+          <span class="display" style="font-size:72px; line-height:0.9; font-weight:500; letter-spacing:-0.02em">847</span>
+          <svg viewBox="0 0 24 24" class="w-6 h-6" fill="var(--accent)"><path d="M12 4l9 11H3z"/></svg>
+        </div>
+        <div class="kicker mt-1">Upvotes <span class="mx-1 opacity-50">·</span> 8 hours since launch</div>
+
+        <hr class="rule my-3" />
+
+        <!-- comments -->
+        <div class="flex items-baseline gap-3">
+          <span class="display" style="font-size:36px; line-height:0.9; font-weight:500">32</span>
+          <span class="kicker">comments</span>
+        </div>
+        <div class="kicker mt-1" style="font-size:10px">Top thread: “the missing piece.”</div>
+
+        <hr class="rule my-3" />
+
+        <!-- views -->
+        <div class="flex items-baseline gap-3">
+          <span class="display" style="font-size:36px; line-height:0.9; font-weight:500">12.3K</span>
+          <span class="kicker">page views</span>
+        </div>
+        <div class="kicker mt-1" style="font-size:10px">214 saved · 12 countries · climbing</div>
+      </aside>
+
+      <!-- RIGHT · editorial column -->
+      <div class="col-span-8 flex flex-col" style="border-left:1px solid var(--rule); padding-left:32px">
+
+        <div class="kicker">Hunter's Note</div>
+
+        <blockquote class="em-italic mt-2" style="font-size:19px; line-height:1.4; color:var(--ink); font-weight:400">
+          “Just tried it — the SSE streaming into a sandboxed iframe is exactly the missing piece. This is what I wanted markdown editors to grow up into.”
+        </blockquote>
+
+        <div class="mt-2.5 flex items-center gap-2">
+          <span class="mono text-[12px]" style="color:var(--accent)">— @trq212</span>
+          <span class="mono text-[10px] uppercase" style="color:var(--muted); letter-spacing:0.16em">·· first comment, 14 min after launch</span>
+        </div>
+
+        <div class="mt-4" style="width:60px; height:1px; background:var(--ink)"></div>
+
+        <div class="kicker mt-3">Filed Under</div>
+        <div class="mt-1.5" style="font-size:13px; font-weight:500; color:var(--ink)">
+          Developer Tools
+          <span class="mx-2" style="color:var(--rule)">·</span>
+          Open Source
+          <span class="mx-2" style="color:var(--rule)">·</span>
+          Artificial Intelligence
+          <span class="mx-2" style="color:var(--rule)">·</span>
+          <span style="color:var(--muted); font-style:italic">Editorial Tools (new)</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ④ Byline footer -->
+    <footer class="mt-5 px-12 py-3 flex items-center justify-between" style="background:var(--tint); border-top:1px solid var(--rule)">
+      <div class="flex items-center gap-3">
+        <span class="kicker">Hunted by</span>
+        <span class="text-[13px] font-semibold" style="color:var(--ink)">@nexudotio</span>
+        <svg viewBox="0 0 24 24" class="w-3 h-3" fill="var(--accent)"><path d="M12 1.5l3.1 7 7.4.7-5.6 5 1.7 7.3L12 17.6 5.4 21.5 7.1 14.2 1.5 9.2l7.4-.7z"/></svg>
+        <span class="mono text-[10px] uppercase px-1.5 py-[3px]" style="color:var(--ink); letter-spacing:0.14em; border:1px solid var(--rule)">Maker</span>
+      </div>
+      <div class="flex items-center gap-2.5 mono text-[10px] uppercase" style="color:var(--muted); letter-spacing:0.16em">
+        <span>Joined by 32 makers</span>
+        <span style="color:var(--rule)">·</span>
+        <span>12 countries</span>
+        <span style="color:var(--rule)">·</span>
+        <span class="inline-flex items-center gap-1.5" style="color:var(--accent); font-weight:600">
+          <span class="blink-dot inline-block w-[7px] h-[7px] rounded-full" style="background:var(--accent)"></span>
+          Live now
+        </span>
+      </div>
+    </footer>
+  </article>
+</body>
+</html>

--- a/next/src/lib/templates/skills/social-product-hunt-card/example.md
+++ b/next/src/lib/templates/skills/social-product-hunt-card/example.md
@@ -1,0 +1,28 @@
+## Product launch context
+
+We're launching **HTML Anything** on Product Hunt today, May 14.
+
+**Tagline (one line, ≤ 80 chars):**
+Markdown is the draft. HTML is what humans read. Your local agent writes it.
+
+**Why it matters:**
+Claude Code's team stopped writing internal docs in Markdown — they ship HTML now. HTML Anything is the agent-era HTML editor: detects 8 coding-agent CLIs on your `$PATH`, picks one of 75 skill templates, streams output into a sandboxed iframe, and one-click exports to WeChat / X / Zhihu / `.html` / `.png`.
+
+**Topics (pick 3, in PH-canonical order):**
+- Developer Tools
+- Open Source
+- Artificial Intelligence
+
+**Hunter / Maker:** @nexudotio (Maker)
+
+**Stats so far (live):**
+- 847 upvotes
+- 32 comments
+- 214 saves
+- 12.3K views
+- Joined by 32 makers from 12 countries
+
+**Latest comment to feature:**
+@trq212 — "Just tried it — the SSE streaming into a sandboxed iframe is exactly the missing piece." (just now)
+
+**Ranking:** #1 Product of the Day


### PR DESCRIPTION
## Summary

A new skill — `social-product-hunt-card` — that renders Product Hunt launches as **Sunday-newspaper front pages** instead of the usual rounded-orange SaaS card. Sits inside the editorial signature already established by `deck-guizang-editorial`, `magazine-poster`, and `doc-kami-parchment`: Playfair Display + warm paper + brick accent + 1px hairlines, zero shadows / gradients / round corners.

The signature design move — *"today's launch as front-page news"*: masthead with star ornaments and a 1px+4px double rule, big italic-accented serif headline, Playfair-italic lede, two-column body grid (editorial number stack on the left + Hunter's Note pull-quote on the right), middle-dot-separated topics (no pills), newspaper byline footer with `LIVE NOW` blink dot.

<img width="1200" height="1100" alt="social-product-hunt-card-v2-full" src="https://github.com/user-attachments/assets/57627ad6-5464-4b3e-9a7c-98552f2de6d5" />

## Hard-locked design system

Mirrored in `SKILL.md` and `example.html`:

- **5 hex tokens only** — paper `#f3eee2`, tint `#ece5d3`, ink `#1f1c17`, muted `#6e6a5d`, rule `#d3cdbe`, accent `#c2492c` (brick-orange, between PH brand `#DA552F` and editorial `#b85a3a` — preserves PH brand recognition without going garish).
- **3 fonts with strict roles** — Playfair Display (display + lede italic + big numbers), Inter (body + kicker), JetBrains Mono with `tnum` (metrics, dateline, folio).
- **Hard bans** — 0 drop-shadow, 0 gradient backgrounds, 0 corner-radius ≥ 4px, 0 blur, 0 multi-color accents. All forbidden in the prompt body and absent from the example.
- Subtle 16px radial-dot grain pattern overlaid on the paper bg.

## Files

One folder; no registration step (picker auto-discovers via `src/lib/templates/loader.ts`):

| File | Purpose |
|---|---|
| `src/lib/templates/skills/social-product-hunt-card/SKILL.md` | frontmatter (zh/en, `category: card`, `scenario: marketing`, `aspect_hint: 1200×630`, 6 tags) + prompt body locking the design system above. |
| `src/lib/templates/skills/social-product-hunt-card/example.html` | hand-authored 1120×~660 OG card showing html-anything itself as the launching product (self-referential — the maintainers' own future PH launch is the demo). |
| `src/lib/templates/skills/social-product-hunt-card/example.md` | launch-context input shape designed to teach the agent how to elevate a tagline into editorial headline + lede. |

## CONTRIBUTING merge-bar (per [`CONTRIBUTING.md`](CONTRIBUTING.md))

- [x] Real `example.html` ships in the folder
- [x] Renders cleanly in Chrome headless at 1200×720 (see screenshot above)
- [x] Hard constraints are specific (hex codes, font roles, px sizes, letter-spacing — not vague directives like "use modern typography")
- [x] No `lorem ipsum`; example uses real product copy
- [x] Slug uses ASCII lowercase with dashes; mirrors `social-x-post-card`, `social-spotify-card`, `social-reddit-card`
- [x] Not vendored from another repo — no third-party LICENSE to ship

## Test plan

- [ ] `pnpm dev` → open picker → confirm `Product Hunt 头版报` appears under the **Card / 卡** group
- [ ] Click the skill → load the bundled sample → ⌘+Enter to convert with an installed agent (Claude / Cursor / Gemini / …)
- [ ] Generated HTML respects the design tokens: paper bg `#f3eee2`, brick accent `#c2492c`, Playfair masthead, 1px hairlines, no shadows, no rounded corners ≥ 4px
- [ ] One-click `.png` export works against the generated card

## Why this skill

The catalog already has `social-x-post-card`, `social-reddit-card`, `social-spotify-card` — but **no Product Hunt launch card**, the single most-shared social artifact in dev-tool launches. And rather than mimic producthunt.com's UI (every PH-launch screenshot already does that), this skill reframes the moment: launch day is news, so the card is a newspaper front page. That's the signature. It also gives the project itself a ready-to-use OG card for its own eventual PH launch.