### PR TITLE
feat(export): Hyperframes → Remotion project (.zip)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:ui": "playwright test"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -26,6 +27,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/dompurify": "^3.2.0",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/ui",
+  fullyParallel: true,
+  timeout: 30_000,
+  expect: {
+    timeout: 7_500,
+  },
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3317",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev -- -p 3317",
+    url: "http://localhost:3317",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 4.7.0
       next:
         specifier: 16.2.6
-        version: 16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -54,6 +54,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -118,105 +121,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -277,28 +264,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -311,6 +294,11 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -353,28 +341,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -541,6 +525,11 @@ packages:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -622,28 +611,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -731,6 +716,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -1033,6 +1028,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -1239,6 +1238,9 @@ snapshots:
 
   frac@1.1.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   graceful-fs@4.2.11: {}
 
   highlight.js@11.11.1: {}
@@ -1355,7 +1357,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  next@16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -1374,6 +1376,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -1401,6 +1404,14 @@ snapshots:
       entities: 6.0.1
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:

--- a/src/components/export-menu.tsx
+++ b/src/components/export-menu.tsx
@@ -18,6 +18,8 @@ import {
   exportDeckPptx,
   exportDeckPrint,
 } from "@/lib/export/deck";
+import { parseHyperframes } from "@/lib/hyperframes";
+import { exportRemotionZip } from "@/lib/export/remotion";
 
 type ExportMenuProps = {
   iframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
@@ -65,6 +67,7 @@ export function ExportMenu({ iframeRef }: ExportMenuProps) {
   // Re-parse for the deck section. Cheap because parseDeck is regex-only and
   // the menu only opens on user click.
   const deck = useMemo(() => parseDeck(extractHtml(html)), [html]);
+  const hyperframes = useMemo(() => parseHyperframes(extractHtml(html)), [html]);
 
   const sections: Array<{
     title: string;
@@ -125,6 +128,25 @@ export function ExportMenu({ iframeRef }: ExportMenuProps) {
                 emoji: "🎬",
                 fn: wrap(t("export.toast.deckPptx"), async () => {
                   await exportDeckPptx(deck.slides, deck.title);
+                }),
+              },
+            ],
+          },
+        ]
+      : []),
+    ...(hyperframes.isHyperframes
+      ? [
+          {
+            title: t("export.section.hyperframes", { n: hyperframes.frames.length }),
+            actions: [
+              {
+                id: "hyperframes-remotion-zip",
+                label: t("export.action.remotionZip"),
+                emoji: "🎞️",
+                fn: wrap(t("export.toast.remotionZip"), async () => {
+                  await exportRemotionZip(hyperframes, hyperframes.title, {
+                    sourceHtml: cleanHtml(),
+                  });
                 }),
               },
             ],

--- a/src/components/export-menu.tsx
+++ b/src/components/export-menu.tsx
@@ -164,6 +164,7 @@ export function ExportMenu({ iframeRef }: ExportMenuProps) {
       </button>
       {open && (
         <div
+          data-testid="export-menu"
           className="absolute right-0 z-30 mt-2 w-72 od-fade-in overflow-hidden rounded-2xl"
           style={{
             background: "var(--surface)",

--- a/src/lib/export/remotion.ts
+++ b/src/lib/export/remotion.ts
@@ -168,7 +168,7 @@ export const Root: React.FC = () => {
 
 const FRAME_TSX = `import * as React from "react";
 import { useEffect, useRef, useState } from "react";
-import { AbsoluteFill, delayRender, continueRender } from "remotion";
+import { AbsoluteFill, delayRender, continueRender, staticFile } from "remotion";
 
 type Props = {
   /** Path under public/, e.g. "frames/frame-01.html". */
@@ -217,7 +217,7 @@ export const Frame: React.FC<Props> = ({ src, scene }) => {
     <AbsoluteFill style={{ background: "#000" }}>
       <iframe
         ref={ref}
-        src={src}
+        src={staticFile(src)}
         title={scene || src}
         style={{ width: "100%", height: "100%", border: 0, display: "block" }}
         // sandbox left permissive — frames are author-controlled HTML.

--- a/src/lib/export/remotion.ts
+++ b/src/lib/export/remotion.ts
@@ -11,10 +11,10 @@
  * Instead we emit a minimal, ready-to-render Remotion project as a zip. The
  * user unzips, runs `npm install && npx remotion render`, and gets their mp4.
  *
- * Each frame ships as an independent standalone HTML file in `src/frames/`.
- * The Remotion components mount that HTML inside an `<iframe srcdoc>` sized to
- * the composition — this preserves Tailwind CDN / fonts / inline <style>
- * exactly as authored, no JSX conversion needed.
+ * Each frame ships as an independent standalone HTML file under `public/frames/`.
+ * The Remotion components mount that HTML inside an `<iframe>` sized to the
+ * composition — this preserves Tailwind CDN / fonts / inline <style> exactly
+ * as authored, no JSX conversion needed.
  */
 
 import type { HyperframesParsed, HyperFrame } from "@/lib/hyperframes";
@@ -100,6 +100,7 @@ const PACKAGE_JSON = (name: string, totalSeconds: number) =>
         "react-dom": "^19.0.0",
         remotion: "^4.0.0",
         "@remotion/cli": "^4.0.0",
+        "@remotion/transitions": "^4.0.0",
       },
       devDependencies: {
         "@types/react": "^19.0.0",
@@ -114,7 +115,9 @@ const PACKAGE_JSON = (name: string, totalSeconds: number) =>
 const TSCONFIG = JSON.stringify(
   {
     compilerOptions: {
-      target: "ES2018",
+      // ES2020+ for Array.prototype.flatMap (used in Video.tsx) and modern
+      // syntax Remotion/Chromium supports natively.
+      target: "ES2020",
       module: "ESNext",
       jsx: "react-jsx",
       strict: true,
@@ -145,7 +148,8 @@ import { Root } from "./Root";
 registerRoot(Root);
 `;
 
-const ROOT_TSX = (totalFrames: number) => `import { Composition } from "remotion";
+const ROOT_TSX = (totalFrames: number) => `import * as React from "react";
+import { Composition } from "remotion";
 import { Hyperframes } from "./Video";
 
 export const Root: React.FC = () => {
@@ -162,16 +166,15 @@ export const Root: React.FC = () => {
 };
 `;
 
-const FRAME_TSX = `import { AbsoluteFill, useCurrentFrame, interpolate, delayRender, continueRender } from "remotion";
+const FRAME_TSX = `import * as React from "react";
 import { useEffect, useRef, useState } from "react";
+import { AbsoluteFill, delayRender, continueRender } from "remotion";
 
 type Props = {
   /** Path under public/, e.g. "frames/frame-01.html". */
   src: string;
-  /** Sequence length in frames. */
-  durationInFrames: number;
-  /** Cross-fade window (frames). 0 = hard cut. */
-  fadeFrames: number;
+  /** Optional scene summary — used as the iframe title for a11y. */
+  scene?: string;
 };
 
 /**
@@ -179,40 +182,43 @@ type Props = {
  * inside an iframe at native 1920×1080 — preserves Tailwind CDN / fonts /
  * custom <style> verbatim. We block Remotion's render with delayRender() until
  * the iframe's load event fires so the screenshot captures fully-loaded CSS.
+ *
+ * Cross-fade transitions are NOT done here — they're handled by
+ * <TransitionSeries.Transition presentation={fade()}/> in Video.tsx so adjacent
+ * frames actually overlap instead of dipping to black.
  */
-export const Frame: React.FC<Props> = ({ src, durationInFrames, fadeFrames }) => {
-  const frame = useCurrentFrame();
+export const Frame: React.FC<Props> = ({ src, scene }) => {
   const ref = useRef<HTMLIFrameElement>(null);
   const [handle] = useState(() => delayRender("Loading iframe: " + src));
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    if (el.contentDocument?.readyState === "complete") {
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
       continueRender(handle);
+    };
+    if (el.contentDocument?.readyState === "complete") {
+      release();
       return;
     }
-    const onLoad = () => continueRender(handle);
-    el.addEventListener("load", onLoad, { once: true });
-    return () => el.removeEventListener("load", onLoad);
+    el.addEventListener("load", release, { once: true });
+    // Always release on unmount — Remotion warns about leaked handles if the
+    // sequence ends before the iframe's load event fires.
+    return () => {
+      el.removeEventListener("load", release);
+      release();
+    };
   }, [handle]);
 
-  const fade = Math.max(0, Math.min(fadeFrames, Math.floor(durationInFrames / 3)));
-  const opacity =
-    fade === 0
-      ? 1
-      : interpolate(
-          frame,
-          [0, fade, durationInFrames - fade, durationInFrames],
-          [0, 1, 1, 0],
-          { extrapolateLeft: "clamp", extrapolateRight: "clamp" },
-        );
-
   return (
-    <AbsoluteFill style={{ opacity, background: "#000" }}>
+    <AbsoluteFill style={{ background: "#000" }}>
       <iframe
         ref={ref}
         src={src}
+        title={scene || src}
         style={{ width: "100%", height: "100%", border: 0, display: "block" }}
         // sandbox left permissive — frames are author-controlled HTML.
       />
@@ -221,17 +227,24 @@ export const Frame: React.FC<Props> = ({ src, durationInFrames, fadeFrames }) =>
 };
 `;
 
-type SequenceEntry = { src: string; durationInFrames: number; transition: string };
+type SequenceEntry = {
+  src: string;
+  durationInFrames: number;
+  transition: string;
+  scene: string;
+};
 
 const VIDEO_TSX = (entries: SequenceEntry[]) => {
   const items = entries
     .map(
       (e, i) =>
-        `  { src: "${e.src}", durationInFrames: ${e.durationInFrames}, transition: "${e.transition}" }${i === entries.length - 1 ? "" : ","}`,
+        `  { src: ${JSON.stringify(e.src)}, durationInFrames: ${e.durationInFrames}, transition: ${JSON.stringify(e.transition)}, scene: ${JSON.stringify(e.scene)} }${i === entries.length - 1 ? "" : ","}`,
     )
     .join("\n");
 
-  return `import { Series } from "remotion";
+  return `import * as React from "react";
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
 import { Frame } from "./Frame";
 
 const FADE_FRAMES = ${FADE_FRAMES};
@@ -240,35 +253,68 @@ const FRAMES = [
 ${items}
 ];
 
+/**
+ * <TransitionSeries> overlaps adjacent <Sequence>s by the transition's
+ * durationInFrames, so a "fade" here is a real cross-fade — not the dip-to-
+ * black you'd get from animating opacity inside back-to-back <Series>.
+ *
+ * Each transition consumes FADE_FRAMES from BOTH neighbours, so total
+ * composition length = sum(sequences) - sum(active transitions). The Root
+ * composition's durationInFrames is precomputed by the exporter to match.
+ */
 export const Hyperframes: React.FC = () => {
   return (
-    <Series>
-      {FRAMES.map((f, i) => (
-        <Series.Sequence key={i} durationInFrames={f.durationInFrames}>
-          <Frame
-            src={f.src}
+    <TransitionSeries>
+      {FRAMES.flatMap((f, i) => {
+        const seq = (
+          <TransitionSeries.Sequence
+            key={\`s-\${i}\`}
             durationInFrames={f.durationInFrames}
-            fadeFrames={f.transition === "fade" ? FADE_FRAMES : 0}
-          />
-        </Series.Sequence>
-      ))}
-    </Series>
+          >
+            <Frame src={f.src} scene={f.scene} />
+          </TransitionSeries.Sequence>
+        );
+        const isLast = i === FRAMES.length - 1;
+        if (isLast || f.transition !== "fade") return [seq];
+        return [
+          seq,
+          <TransitionSeries.Transition
+            key={\`t-\${i}\`}
+            presentation={fade()}
+            timing={linearTiming({ durationInFrames: FADE_FRAMES })}
+          />,
+        ];
+      })}
+    </TransitionSeries>
   );
 };
 `;
 };
 
-const README_MD = (basename: string, frames: HyperFrame[], totalSeconds: number) => {
+const README_MD = (
+  basename: string,
+  sourceTitle: string,
+  frames: HyperFrame[],
+  totalSeconds: number,
+) => {
+  // Preserve the (possibly non-ASCII) original title — `basename` is the
+  // ASCII-only slug used for filenames.
+  const heading =
+    sourceTitle && sourceTitle.toLowerCase() !== basename ? sourceTitle : basename;
   const list = frames
-    .map((f) => `- frame ${pad(f.i)} · ${(f.duration / 1000).toFixed(1)}s · ${f.transition} · ${f.scene || "(no scene)"}`)
+    .map(
+      (f) =>
+        `- frame ${pad(f.i)} · ${(f.duration / 1000).toFixed(1)}s · ${f.transition} · ${f.scene || "(no scene)"}`,
+    )
     .join("\n");
-  return `# ${basename}
+  return `# ${heading}
 
 Auto-generated Remotion project from a Hyperframes HTML doc.
 
 - ${frames.length} frames · ~${totalSeconds.toFixed(1)}s · ${CANVAS_W}×${CANVAS_H} @ ${FPS} fps
 - Source HTML preserved at \`hyperframes.html\`
 - Each frame is a standalone HTML doc under \`public/frames/\` and is mounted in an \`<iframe>\` by \`src/Frame.tsx\`
+- Cross-fades use \`<TransitionSeries>\` + \`@remotion/transitions/fade\` (real overlap, not dip-to-black)
 
 ## Render to mp4
 
@@ -286,6 +332,11 @@ npx remotion studio
 Then open the Hyperframes composition. Edit frame timings or transitions by
 changing the \`FRAMES\` array in \`src/Video.tsx\`.
 
+## Notes
+
+- **Render is single-threaded by default** (\`Config.setConcurrency(1)\` in \`remotion.config.ts\`) because each frame's iframe re-fetches Tailwind from \`cdn.tailwindcss.com\` on mount. Expect render time roughly proportional to N × (CDN load + screenshot). To speed up: bump concurrency in \`remotion.config.ts\`, or replace the CDN \`<script>\` in each \`public/frames/frame-NN.html\` with a precompiled stylesheet.
+- **Relative asset URLs inside a frame's HTML will 404.** Each frame is served from \`public/frames/frame-NN.html\`, so \`<img src="logo.png">\` resolves to \`/frames/logo.png\`. Either drop the asset under \`public/frames/\`, inline it as a data-URL, or use an absolute URL.
+
 ## Frames
 
 ${list}
@@ -299,8 +350,6 @@ ${list}
 export type ExportRemotionOptions = {
   /** Original HTML source — included in the zip for reference / re-renders. */
   sourceHtml?: string;
-  /** Progress callback for the UI. */
-  onProgress?: (step: string) => void;
 };
 
 /**
@@ -317,8 +366,6 @@ export async function exportRemotionZip(
     throw new Error("no frames — not a Hyperframes document");
   }
 
-  opts.onProgress?.("Bundling Remotion project");
-
   // Lazy-load JSZip — keeps the initial route bundle small.
   const { default: JSZip } = await import("jszip");
   const zip = new JSZip();
@@ -334,25 +381,33 @@ export async function exportRemotionZip(
       src: filename,
       durationInFrames: msToFrames(f.duration),
       transition: f.transition || "fade",
+      scene: f.scene || "",
     };
   });
 
-  const totalFrames = sequenceEntries.reduce((sum, e) => sum + e.durationInFrames, 0);
-  const totalSeconds = totalFrames / FPS;
+  // <TransitionSeries> transitions OVERLAP both adjacent sequences, so the
+  // composition is shorter than sum(sequences) by FADE_FRAMES per active
+  // transition. The transition between sequence i and i+1 is driven by
+  // entries[i].transition (matches Video.tsx).
+  const sequenceTotal = sequenceEntries.reduce((sum, e) => sum + e.durationInFrames, 0);
+  const transitionOverlap = sequenceEntries
+    .slice(0, -1)
+    .reduce((sum, e) => sum + (e.transition === "fade" ? FADE_FRAMES : 0), 0);
+  const compositionFrames = Math.max(1, sequenceTotal - transitionOverlap);
+  const totalSeconds = compositionFrames / FPS;
 
   zip.file("package.json", PACKAGE_JSON(name, totalSeconds));
   zip.file("tsconfig.json", TSCONFIG);
   zip.file("remotion.config.ts", REMOTION_CONFIG);
   zip.file("src/index.ts", INDEX_TS);
-  zip.file("src/Root.tsx", ROOT_TSX(totalFrames));
+  zip.file("src/Root.tsx", ROOT_TSX(compositionFrames));
   zip.file("src/Video.tsx", VIDEO_TSX(sequenceEntries));
   zip.file("src/Frame.tsx", FRAME_TSX);
-  zip.file("README.md", README_MD(name, parsed.frames, totalSeconds));
+  zip.file("README.md", README_MD(name, parsed.title, parsed.frames, totalSeconds));
   if (opts.sourceHtml) zip.file("hyperframes.html", opts.sourceHtml);
   // Stash META JSON for round-tripping / debugging.
   if (parsed.metaJson) zip.file("hyperframes.meta.json", parsed.metaJson);
 
-  opts.onProgress?.("Compressing");
   const out = await zip.generateAsync({ type: "blob" });
   downloadBlob(out, `${name}-remotion-${Date.now()}.zip`);
 }

--- a/src/lib/export/remotion.ts
+++ b/src/lib/export/remotion.ts
@@ -1,0 +1,358 @@
+"use client";
+
+/**
+ * Hyperframes → Remotion project (.zip).
+ *
+ * We do NOT render an mp4 in the browser or on the server — that would require
+ * either ffmpeg.wasm (huge bundle, slow, breaks on long videos) or a
+ * long-running server process (forbidden, see CONTRIBUTING.md "no daemon, no
+ * extra processes").
+ *
+ * Instead we emit a minimal, ready-to-render Remotion project as a zip. The
+ * user unzips, runs `npm install && npx remotion render`, and gets their mp4.
+ *
+ * Each frame ships as an independent standalone HTML file in `src/frames/`.
+ * The Remotion components mount that HTML inside an `<iframe srcdoc>` sized to
+ * the composition — this preserves Tailwind CDN / fonts / inline <style>
+ * exactly as authored, no JSX conversion needed.
+ */
+
+import type { HyperframesParsed, HyperFrame } from "@/lib/hyperframes";
+import { downloadBlob } from "./image";
+
+const FPS = 30;
+const CANVAS_W = 1920;
+const CANVAS_H = 1080;
+/** Cross-fade window in frames (≈ 0.4s at 30fps). */
+const FADE_FRAMES = 12;
+
+/** Slugify the document title for the zip filename. */
+function slug(s: string, fallback: string): string {
+  const out = s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  return out || fallback;
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/** ms → frames at FPS (rounded, minimum 1 frame). */
+function msToFrames(ms: number): number {
+  return Math.max(1, Math.round((ms / 1000) * FPS));
+}
+
+/**
+ * Build a standalone HTML document for one frame. The original document's
+ * `<head>` is preserved so Tailwind CDN, web fonts, and inline styles all
+ * keep working when Remotion loads this inside an iframe.
+ */
+function buildFrameHtml(parsed: HyperframesParsed, frame: HyperFrame): string {
+  // Neutralise the autoplay script + global flex centering from the source
+  // doc — inside the iframe each frame stands alone at 1920×1080.
+  const resetCss = `
+  html, body { margin:0; padding:0; width:${CANVAS_W}px; height:${CANVAS_H}px; overflow:hidden; }
+  .frame { display:flex !important; opacity:1 !important; transform:none !important; }
+  /* Hide the original deck's controls/progress UI if any leaked into <head>. */
+  .controls, #progress, .progress-bar { display:none !important; }
+`.trim();
+
+  const bodyAttrs = [
+    parsed.bodyClass ? `class="${parsed.bodyClass}"` : "",
+    parsed.bodyStyle ? `style="${parsed.bodyStyle}"` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+${parsed.head}
+<style>${resetCss}</style>
+</head>
+<body ${bodyAttrs}>
+<section class="frame active" data-duration="${frame.duration}">
+${frame.innerHtml}
+</section>
+</body>
+</html>`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Remotion project source templates                                          */
+/* -------------------------------------------------------------------------- */
+
+const PACKAGE_JSON = (name: string, totalSeconds: number) =>
+  JSON.stringify(
+    {
+      name,
+      version: "1.0.0",
+      private: true,
+      description: `Hyperframes → Remotion project (≈${totalSeconds.toFixed(1)}s, ${CANVAS_W}×${CANVAS_H} @ ${FPS}fps)`,
+      scripts: {
+        start: "remotion studio",
+        render: "remotion render Hyperframes out/video.mp4",
+        upgrade: "remotion upgrade",
+      },
+      dependencies: {
+        react: "^19.0.0",
+        "react-dom": "^19.0.0",
+        remotion: "^4.0.0",
+        "@remotion/cli": "^4.0.0",
+      },
+      devDependencies: {
+        "@types/react": "^19.0.0",
+        "@types/node": "^20.0.0",
+        typescript: "^5.0.0",
+      },
+    },
+    null,
+    2,
+  );
+
+const TSCONFIG = JSON.stringify(
+  {
+    compilerOptions: {
+      target: "ES2018",
+      module: "ESNext",
+      jsx: "react-jsx",
+      strict: true,
+      moduleResolution: "Bundler",
+      esModuleInterop: true,
+      skipLibCheck: true,
+      resolveJsonModule: true,
+      allowSyntheticDefaultImports: true,
+    },
+    include: ["src"],
+  },
+  null,
+  2,
+);
+
+const REMOTION_CONFIG = `import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg");
+Config.setConcurrency(1);
+// Hyperframes load Tailwind via CDN inside an iframe — give it room to load.
+Config.setDelayRenderTimeoutInMilliseconds(60_000);
+Config.setChromiumOpenGlRenderer("angle");
+`;
+
+const INDEX_TS = `import { registerRoot } from "remotion";
+import { Root } from "./Root";
+
+registerRoot(Root);
+`;
+
+const ROOT_TSX = (totalFrames: number) => `import { Composition } from "remotion";
+import { Hyperframes } from "./Video";
+
+export const Root: React.FC = () => {
+  return (
+    <Composition
+      id="Hyperframes"
+      component={Hyperframes}
+      durationInFrames={${totalFrames}}
+      fps={${FPS}}
+      width={${CANVAS_W}}
+      height={${CANVAS_H}}
+    />
+  );
+};
+`;
+
+const FRAME_TSX = `import { AbsoluteFill, useCurrentFrame, interpolate, delayRender, continueRender } from "remotion";
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  /** Path under public/, e.g. "frames/frame-01.html". */
+  src: string;
+  /** Sequence length in frames. */
+  durationInFrames: number;
+  /** Cross-fade window (frames). 0 = hard cut. */
+  fadeFrames: number;
+};
+
+/**
+ * One frame of the Hyperframes video. Renders the original standalone HTML
+ * inside an iframe at native 1920×1080 — preserves Tailwind CDN / fonts /
+ * custom <style> verbatim. We block Remotion's render with delayRender() until
+ * the iframe's load event fires so the screenshot captures fully-loaded CSS.
+ */
+export const Frame: React.FC<Props> = ({ src, durationInFrames, fadeFrames }) => {
+  const frame = useCurrentFrame();
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [handle] = useState(() => delayRender("Loading iframe: " + src));
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (el.contentDocument?.readyState === "complete") {
+      continueRender(handle);
+      return;
+    }
+    const onLoad = () => continueRender(handle);
+    el.addEventListener("load", onLoad, { once: true });
+    return () => el.removeEventListener("load", onLoad);
+  }, [handle]);
+
+  const fade = Math.max(0, Math.min(fadeFrames, Math.floor(durationInFrames / 3)));
+  const opacity =
+    fade === 0
+      ? 1
+      : interpolate(
+          frame,
+          [0, fade, durationInFrames - fade, durationInFrames],
+          [0, 1, 1, 0],
+          { extrapolateLeft: "clamp", extrapolateRight: "clamp" },
+        );
+
+  return (
+    <AbsoluteFill style={{ opacity, background: "#000" }}>
+      <iframe
+        ref={ref}
+        src={src}
+        style={{ width: "100%", height: "100%", border: 0, display: "block" }}
+        // sandbox left permissive — frames are author-controlled HTML.
+      />
+    </AbsoluteFill>
+  );
+};
+`;
+
+type SequenceEntry = { src: string; durationInFrames: number; transition: string };
+
+const VIDEO_TSX = (entries: SequenceEntry[]) => {
+  const items = entries
+    .map(
+      (e, i) =>
+        `  { src: "${e.src}", durationInFrames: ${e.durationInFrames}, transition: "${e.transition}" }${i === entries.length - 1 ? "" : ","}`,
+    )
+    .join("\n");
+
+  return `import { Series } from "remotion";
+import { Frame } from "./Frame";
+
+const FADE_FRAMES = ${FADE_FRAMES};
+
+const FRAMES = [
+${items}
+];
+
+export const Hyperframes: React.FC = () => {
+  return (
+    <Series>
+      {FRAMES.map((f, i) => (
+        <Series.Sequence key={i} durationInFrames={f.durationInFrames}>
+          <Frame
+            src={f.src}
+            durationInFrames={f.durationInFrames}
+            fadeFrames={f.transition === "fade" ? FADE_FRAMES : 0}
+          />
+        </Series.Sequence>
+      ))}
+    </Series>
+  );
+};
+`;
+};
+
+const README_MD = (basename: string, frames: HyperFrame[], totalSeconds: number) => {
+  const list = frames
+    .map((f) => `- frame ${pad(f.i)} · ${(f.duration / 1000).toFixed(1)}s · ${f.transition} · ${f.scene || "(no scene)"}`)
+    .join("\n");
+  return `# ${basename}
+
+Auto-generated Remotion project from a Hyperframes HTML doc.
+
+- ${frames.length} frames · ~${totalSeconds.toFixed(1)}s · ${CANVAS_W}×${CANVAS_H} @ ${FPS} fps
+- Source HTML preserved at \`hyperframes.html\`
+- Each frame is a standalone HTML doc under \`public/frames/\` and is mounted in an \`<iframe>\` by \`src/Frame.tsx\`
+
+## Render to mp4
+
+\`\`\`bash
+npm install
+npx remotion render Hyperframes out/video.mp4
+\`\`\`
+
+## Preview / tweak
+
+\`\`\`bash
+npx remotion studio
+\`\`\`
+
+Then open the Hyperframes composition. Edit frame timings or transitions by
+changing the \`FRAMES\` array in \`src/Video.tsx\`.
+
+## Frames
+
+${list}
+`;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type ExportRemotionOptions = {
+  /** Original HTML source — included in the zip for reference / re-renders. */
+  sourceHtml?: string;
+  /** Progress callback for the UI. */
+  onProgress?: (step: string) => void;
+};
+
+/**
+ * Build a Remotion project zip from parsed Hyperframes and trigger the
+ * browser download. No server, no ffmpeg, no rendering happens here — the
+ * user runs `npx remotion render` locally to produce the mp4.
+ */
+export async function exportRemotionZip(
+  parsed: HyperframesParsed,
+  basename = "hyperframes",
+  opts: ExportRemotionOptions = {},
+): Promise<void> {
+  if (!parsed.isHyperframes || parsed.frames.length === 0) {
+    throw new Error("no frames — not a Hyperframes document");
+  }
+
+  opts.onProgress?.("Bundling Remotion project");
+
+  // Lazy-load JSZip — keeps the initial route bundle small.
+  const { default: JSZip } = await import("jszip");
+  const zip = new JSZip();
+
+  const name = slug(basename, "hyperframes");
+
+  // Per-frame standalone HTML lives under public/ so Remotion's bundler
+  // serves it as a static asset addressable by relative URL.
+  const sequenceEntries: SequenceEntry[] = parsed.frames.map((f) => {
+    const filename = `frames/frame-${pad(f.i)}.html`;
+    zip.file(`public/${filename}`, buildFrameHtml(parsed, f));
+    return {
+      src: filename,
+      durationInFrames: msToFrames(f.duration),
+      transition: f.transition || "fade",
+    };
+  });
+
+  const totalFrames = sequenceEntries.reduce((sum, e) => sum + e.durationInFrames, 0);
+  const totalSeconds = totalFrames / FPS;
+
+  zip.file("package.json", PACKAGE_JSON(name, totalSeconds));
+  zip.file("tsconfig.json", TSCONFIG);
+  zip.file("remotion.config.ts", REMOTION_CONFIG);
+  zip.file("src/index.ts", INDEX_TS);
+  zip.file("src/Root.tsx", ROOT_TSX(totalFrames));
+  zip.file("src/Video.tsx", VIDEO_TSX(sequenceEntries));
+  zip.file("src/Frame.tsx", FRAME_TSX);
+  zip.file("README.md", README_MD(name, parsed.frames, totalSeconds));
+  if (opts.sourceHtml) zip.file("hyperframes.html", opts.sourceHtml);
+  // Stash META JSON for round-tripping / debugging.
+  if (parsed.metaJson) zip.file("hyperframes.meta.json", parsed.metaJson);
+
+  opts.onProgress?.("Compressing");
+  const out = await zip.generateAsync({ type: "blob" });
+  downloadBlob(out, `${name}-remotion-${Date.now()}.zip`);
+}

--- a/src/lib/hyperframes.ts
+++ b/src/lib/hyperframes.ts
@@ -1,0 +1,173 @@
+/**
+ * Hyperframes mode helpers.
+ *
+ * The `video-hyperframes` skill (see
+ * `src/lib/templates/skills/video-hyperframes/SKILL.md`) emits a document with
+ *
+ *   <section class="frame" data-duration="3000"> … </section>
+ *   …
+ *   <!-- HYPERFRAMES_META: {"frames":[{"i":1,"duration":3000,...}, …]} -->
+ *
+ * This module extracts the per-frame body + the META JSON so an exporter can
+ * stamp out a Remotion project (one component per frame).
+ */
+export type HyperframeMetaEntry = {
+  i: number;
+  duration: number;
+  transition?: string;
+  scene?: string;
+};
+
+export type HyperFrame = {
+  /** 1-based index from META, or DOM order */
+  i: number;
+  /** ms */
+  duration: number;
+  transition: string;
+  scene: string;
+  /** Inner HTML of the <section class="frame"> (no wrapper) */
+  innerHtml: string;
+  /** Best-effort background colour from inline style */
+  bg?: string;
+};
+
+export type HyperframesParsed = {
+  isHyperframes: boolean;
+  frames: HyperFrame[];
+  /** Original `<head>` contents (Tailwind CDN, fonts, inline <style>) */
+  head: string;
+  /** Body classes/style — re-applied to each frame component wrapper */
+  bodyClass: string;
+  bodyStyle: string;
+  /** Document title for filenames */
+  title: string;
+  /** Source META JSON, if present */
+  metaJson: string;
+};
+
+const FRAME_RE =
+  /<section\b[^>]*\bclass\s*=\s*["'][^"']*\bframe\b[^"']*["'][^>]*>([\s\S]*?)<\/section>/gi;
+const META_RE = /<!--\s*HYPERFRAMES_META\s*:\s*([\s\S]*?)-->/i;
+
+/** Cheap test — true if the document looks like a Hyperframes video. */
+export function isHyperframes(html: string): boolean {
+  if (!html) return false;
+  FRAME_RE.lastIndex = 0;
+  return FRAME_RE.test(html);
+}
+
+function pick(re: RegExp, src: string): string {
+  const m = re.exec(src);
+  return m ? m[1] : "";
+}
+
+function stripTags(s: string): string {
+  return s
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractAttr(tag: string, name: string): string {
+  const re = new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`, "i");
+  return pick(re, tag);
+}
+
+function parseMeta(html: string): { json: string; entries: HyperframeMetaEntry[] } {
+  const raw = pick(META_RE, html).trim();
+  if (!raw) return { json: "", entries: [] };
+  try {
+    const parsed = JSON.parse(raw) as { frames?: HyperframeMetaEntry[] };
+    if (!parsed || !Array.isArray(parsed.frames)) return { json: raw, entries: [] };
+    return { json: raw, entries: parsed.frames };
+  } catch {
+    // META is best-effort — agents sometimes emit slightly invalid JSON. We
+    // fall back to per-frame `data-duration` / inline-comment markers.
+    return { json: raw, entries: [] };
+  }
+}
+
+/**
+ * Pull duration / transition out of the inline `<!-- frame:N duration:3000
+ * transition:fade -->` marker the skill plants at the bottom of each section.
+ */
+function parseInlineMarker(innerHtml: string): { duration?: number; transition?: string } {
+  const m = /<!--\s*frame\s*:\s*\d+\s+duration\s*:\s*(\d+)(?:\s+transition\s*:\s*(\w+))?\s*-->/i.exec(
+    innerHtml,
+  );
+  if (!m) return {};
+  return { duration: Number(m[1]) || undefined, transition: m[2] };
+}
+
+/**
+ * Parse a full Hyperframes HTML doc.
+ * No-op + isHyperframes:false when the doc has no `<section class="frame">`.
+ */
+export function parseHyperframes(fullHtml: string): HyperframesParsed {
+  const empty: HyperframesParsed = {
+    isHyperframes: false,
+    frames: [],
+    head: "",
+    bodyClass: "",
+    bodyStyle: "",
+    title: "hyperframes",
+    metaJson: "",
+  };
+  if (!isHyperframes(fullHtml)) return empty;
+
+  const head = pick(/<head\b[^>]*>([\s\S]*?)<\/head>/i, fullHtml);
+  const bodyTag = pick(/<body\b([^>]*)>/i, fullHtml);
+  const bodyClass = extractAttr(bodyTag, "class");
+  const bodyStyle = extractAttr(bodyTag, "style");
+  const title = stripTags(pick(/<title\b[^>]*>([\s\S]*?)<\/title>/i, head)) || "hyperframes";
+
+  const { json: metaJson, entries } = parseMeta(fullHtml);
+  const metaByIndex = new Map<number, HyperframeMetaEntry>();
+  for (const e of entries) metaByIndex.set(e.i, e);
+
+  const frames: HyperFrame[] = [];
+  FRAME_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  let idx = 0;
+  while ((m = FRAME_RE.exec(fullHtml))) {
+    idx += 1;
+    const openTag = pick(/<section\b[^>]*>/i, m[0]);
+    const dataDur = Number(extractAttr(openTag, "data-duration")) || undefined;
+    const dataTransition = extractAttr(openTag, "data-transition") || undefined;
+    const inlineStyle = extractAttr(openTag, "style");
+    const bg = pick(/background(?:-color)?\s*:\s*([^;"']+)/i, inlineStyle).trim() || undefined;
+
+    const innerHtml = m[1];
+    const marker = parseInlineMarker(innerHtml);
+    const meta = metaByIndex.get(idx);
+
+    // Priority: META JSON > data-* attributes > inline comment > default
+    const duration = meta?.duration ?? dataDur ?? marker.duration ?? 3000;
+    const transition = meta?.transition ?? dataTransition ?? marker.transition ?? "fade";
+    const scene = meta?.scene ?? "";
+
+    frames.push({
+      i: idx,
+      duration,
+      transition,
+      scene,
+      innerHtml,
+      bg,
+    });
+  }
+
+  return {
+    isHyperframes: frames.length > 0,
+    frames,
+    head,
+    bodyClass,
+    bodyStyle,
+    title,
+    metaJson,
+  };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -192,6 +192,7 @@ export interface Dict {
   "export.section.raw": string;
   "export.section.download": string;
   "export.section.deck": string;
+  "export.section.hyperframes": string;
   "export.action.wechat": string;
   "export.action.zhihu": string;
   "export.action.twitterImg": string;
@@ -202,6 +203,7 @@ export interface Dict {
   "export.action.deckPdf": string;
   "export.action.deckPngZip": string;
   "export.action.deckPptx": string;
+  "export.action.remotionZip": string;
   "export.toast.wechat": string;
   "export.toast.zhihu": string;
   "export.toast.image": string;
@@ -212,6 +214,7 @@ export interface Dict {
   "export.toast.deckPdf": string;
   "export.toast.deckPngZip": string;
   "export.toast.deckPptx": string;
+  "export.toast.remotionZip": string;
   "export.error.previewNotReady": string;
   "export.error.generic": string;
 
@@ -464,6 +467,7 @@ const en: Dict = {
   "export.section.raw": "Copy raw",
   "export.section.download": "Download",
   "export.section.deck": "Deck · {n} slides",
+  "export.section.hyperframes": "Hyperframes · {n} frames",
   "export.action.wechat": "WeChat (公众号)",
   "export.action.zhihu": "Zhihu",
   "export.action.twitterImg": "Twitter / Weibo (PNG)",
@@ -474,6 +478,7 @@ const en: Dict = {
   "export.action.deckPdf": "PDF · all slides (print)",
   "export.action.deckPngZip": "PNG · per-slide (.zip)",
   "export.action.deckPptx": ".pptx · PowerPoint",
+  "export.action.remotionZip": "Remotion project (.zip)",
   "export.toast.wechat": "WeChat format copied",
   "export.toast.zhihu": "Zhihu format copied",
   "export.toast.image": "Image copied",
@@ -484,6 +489,7 @@ const en: Dict = {
   "export.toast.deckPdf": "Print dialog opened — pick “Save as PDF”",
   "export.toast.deckPngZip": "Slide PNGs zipped",
   "export.toast.deckPptx": "PPTX downloaded",
+  "export.toast.remotionZip": "Remotion project zipped — unzip & run `npx remotion render`",
   "export.error.previewNotReady": "Preview not ready",
   "export.error.generic": "failed",
 
@@ -732,6 +738,7 @@ const zhCN: Dict = {
   "export.section.raw": "复制原始内容",
   "export.section.download": "下载",
   "export.section.deck": "Deck · 共 {n} 页",
+  "export.section.hyperframes": "Hyperframes · 共 {n} 帧",
   "export.action.wechat": "微信公众号",
   "export.action.zhihu": "知乎",
   "export.action.twitterImg": "推特 / 微博 (PNG)",
@@ -742,6 +749,7 @@ const zhCN: Dict = {
   "export.action.deckPdf": "PDF · 全部幻灯片 (打印)",
   "export.action.deckPngZip": "PNG · 每页一张 (.zip)",
   "export.action.deckPptx": ".pptx · PowerPoint",
+  "export.action.remotionZip": "Remotion 项目 (.zip)",
   "export.toast.wechat": "已复制公众号格式",
   "export.toast.zhihu": "已复制知乎格式",
   "export.toast.image": "已复制图片",
@@ -752,6 +760,7 @@ const zhCN: Dict = {
   "export.toast.deckPdf": "已打开打印窗口 — 选「另存为 PDF」",
   "export.toast.deckPngZip": "已打包 PNG ZIP",
   "export.toast.deckPptx": "已下载 PPTX",
+  "export.toast.remotionZip": "已打包 Remotion 项目 — 解压后跑 `npx remotion render`",
   "export.error.previewNotReady": "预览未就绪",
   "export.error.generic": "失败",
 

--- a/tests/ui/export-menu.spec.ts
+++ b/tests/ui/export-menu.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Page } from "@playwright/test";
+import JSZip from "jszip";
+import { readFile } from "node:fs/promises";
+
+type SeedOptions = {
+  html: string;
+  content?: string;
+  locale?: "en" | "zh-CN";
+};
+
+const STORE_KEY = "html-everything-store";
+
+const plainHtml = `<!doctype html>
+<html>
+  <head><title>Plain Export</title></head>
+  <body><main><h1>Plain Export</h1><p>No video frames here.</p></main></body>
+</html>`;
+
+const hyperframesHtml = `<!doctype html>
+<html>
+  <head>
+    <title>Sample Reel</title>
+    <style>body { margin: 0; background: #101827; color: white; }</style>
+  </head>
+  <body class="deck-shell" style="font-family: Inter, sans-serif;">
+    <section class="frame active" data-duration="2000" data-transition="fade">
+      <h1>Opening Frame</h1>
+      <!-- frame:1 duration:2000 transition:fade -->
+    </section>
+    <section class="frame" data-duration="3000" data-transition="cut">
+      <h1>Closing Frame</h1>
+      <!-- frame:2 duration:3000 transition:cut -->
+    </section>
+    <!-- HYPERFRAMES_META: {"frames":[{"i":1,"duration":2000,"transition":"fade","scene":"Opening"},{"i":2,"duration":3000,"transition":"cut","scene":"Closing"}]} -->
+  </body>
+</html>`;
+
+async function seedStore(page: Page, opts: SeedOptions) {
+  const now = 1_700_000_000_000;
+  const task = {
+    id: "task_export_ui",
+    name: "Export UI fixture",
+    content: opts.content ?? "Export UI fixture",
+    format: "html",
+    templateId: "video-hyperframes",
+    html: opts.html,
+    status: "done",
+    log: [],
+    stats: { outputBytes: opts.html.length, deltaCount: 1 },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await page.addInitScript(
+    ({ key, taskFixture, locale }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          state: {
+            tasks: [taskFixture],
+            activeTaskId: taskFixture.id,
+            selectedAgent: "test-agent",
+            agentModels: {},
+            welcomeAck: true,
+            sidebarCollapsed: false,
+            locale,
+            layoutMode: "split",
+          },
+          version: 5,
+        }),
+      );
+    },
+    {
+      key: STORE_KEY,
+      taskFixture: task,
+      locale: opts.locale ?? "en",
+    },
+  );
+}
+
+test.describe("Export menu", () => {
+  test("keeps Remotion hidden for regular HTML exports", async ({ page }) => {
+    await seedStore(page, { html: plainHtml });
+
+    await page.goto("/");
+    const exportButton = page.getByRole("button", { name: /export/i });
+    await expect(exportButton).toBeEnabled();
+
+    await exportButton.click();
+    const menu = page.getByTestId("export-menu");
+
+    await expect(menu.getByText("Copy to platform")).toBeVisible();
+    await expect(menu.getByRole("button", { name: /HTML source/ })).toBeVisible();
+    await expect(menu.getByRole("button", { name: /\.html single file/ })).toBeVisible();
+    await expect(menu.getByText(/Hyperframes/)).toHaveCount(0);
+    await expect(menu.getByRole("button", { name: /Remotion project/ })).toHaveCount(0);
+  });
+
+  test("exports a Hyperframes Remotion project zip from the UI", async ({ page }) => {
+    await seedStore(page, { html: hyperframesHtml });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /export/i }).click();
+    const menu = page.getByTestId("export-menu");
+
+    await expect(menu.getByText("Hyperframes · 2 frames")).toBeVisible();
+    const remotionButton = menu.getByRole("button", { name: /Remotion project \(\.zip\)/ });
+    await expect(remotionButton).toBeVisible();
+
+    const downloadPromise = page.waitForEvent("download");
+    await remotionButton.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^sample-reel-remotion-\d+\.zip$/);
+
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+    const zip = await JSZip.loadAsync(await readFile(downloadPath!));
+
+    expect(Object.keys(zip.files).sort()).toEqual(
+      expect.arrayContaining([
+        "README.md",
+        "hyperframes.html",
+        "hyperframes.meta.json",
+        "package.json",
+        "public/frames/frame-01.html",
+        "public/frames/frame-02.html",
+        "remotion.config.ts",
+        "src/Frame.tsx",
+        "src/Root.tsx",
+        "src/Video.tsx",
+        "src/index.ts",
+        "tsconfig.json",
+      ]),
+    );
+
+    const rootTsx = await zip.file("src/Root.tsx")!.async("string");
+    const videoTsx = await zip.file("src/Video.tsx")!.async("string");
+    const frameOne = await zip.file("public/frames/frame-01.html")!.async("string");
+    const readme = await zip.file("README.md")!.async("string");
+
+    expect(rootTsx).toContain("durationInFrames={138}");
+    expect(videoTsx).toContain("TransitionSeries.Transition");
+    expect(videoTsx).toContain("presentation={fade()}");
+    expect(videoTsx).toContain('durationInFrames: 60, transition: "fade", scene: "Opening"');
+    expect(videoTsx).toContain('durationInFrames: 90, transition: "cut", scene: "Closing"');
+    expect(frameOne).toContain('<section class="frame active" data-duration="2000">');
+    expect(frameOne).toContain("Opening Frame");
+    expect(readme).toContain("2 frames");
+    expect(readme).toContain("Cross-fades use");
+
+    await expect(page.getByText(/Remotion project zipped/)).toBeVisible();
+  });
+
+  test("shows the Hyperframes export affordance in Chinese locale", async ({ page }) => {
+    await seedStore(page, { html: hyperframesHtml, locale: "zh-CN" });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /导出/ }).click();
+    const menu = page.getByTestId("export-menu");
+
+    await expect(menu.getByText("Hyperframes · 共 2 帧")).toBeVisible();
+    await expect(menu.getByRole("button", { name: /Remotion 项目 \(\.zip\)/ })).toBeVisible();
+  });
+});

--- a/tests/ui/export-menu.spec.ts
+++ b/tests/ui/export-menu.spec.ts
@@ -136,10 +136,12 @@ test.describe("Export menu", () => {
 
     const rootTsx = await zip.file("src/Root.tsx")!.async("string");
     const videoTsx = await zip.file("src/Video.tsx")!.async("string");
+    const frameTsx = await zip.file("src/Frame.tsx")!.async("string");
     const frameOne = await zip.file("public/frames/frame-01.html")!.async("string");
     const readme = await zip.file("README.md")!.async("string");
 
     expect(rootTsx).toContain("durationInFrames={138}");
+    expect(frameTsx).toContain('staticFile(src)');
     expect(videoTsx).toContain("TransitionSeries.Transition");
     expect(videoTsx).toContain("presentation={fade()}");
     expect(videoTsx).toContain('durationInFrames: 60, transition: "fade", scene: "Opening"');


### PR DESCRIPTION
## Summary

- **New parser** [src/lib/hyperframes.ts](src/lib/hyperframes.ts) reads the `HYPERFRAMES_META` JSON the `video-hyperframes` skill plants at the bottom of its output, plus the per-`<section class="frame">` `data-duration` / inline-comment markers. Resolution priority: META JSON → `data-*` → inline comment → defaults (3000 ms / fade). Mirrors `parseDeck` in shape.
- **New exporter** [src/lib/export/remotion.ts](src/lib/export/remotion.ts) builds a self-contained Remotion 4.x project (`package.json`, `Root.tsx`, `Video.tsx`, `Frame.tsx`, `remotion.config.ts`, per-frame standalone HTML under `public/frames/`) and triggers a browser download via JSZip. Emitted-project deps: `remotion` + `@remotion/cli` + **`@remotion/transitions`** (the last drives the real overlap cross-fade in `Video.tsx` via `<TransitionSeries>` + `fade()` — not a dip-to-black opacity animation). The user then runs `npm install && npx remotion render` locally to get the mp4 — **no server-side ffmpeg, no long-running process**, per the warning in [CONTRIBUTING.md:39](../blob/main/CONTRIBUTING.md#L39).
- **Frame rendering strategy:** each frame is mounted inside an `<iframe>` at native 1920×1080 so Tailwind CDN / web fonts / inline `<style>` survive the JSX boundary unchanged. `delayRender()` blocks Remotion until the iframe's `load` event fires; `delayRenderTimeoutInMilliseconds: 60_000` gives Tailwind CDN room to settle on slower networks.
- **UI** new "Hyperframes · N frames" section in [src/components/export-menu.tsx](src/components/export-menu.tsx), gated on `parseHyperframes(html).isHyperframes` — mirrors the existing Deck section's conditional gating.
- **i18n** 3 new keys × 2 locales.

## Explicitly out of scope

- **"Send to local Remotion Studio"** (mentioned as optional in the original PR-D spec): Remotion Studio is a Vite dev server for an existing on-disk project — there's no documented POST-receive endpoint for an upload. Leaving for a follow-up if it turns out to be feasible.
- **Server-side mp4 rendering**: forbidden by CONTRIBUTING.md's no-daemon principle. The zip-download path is the architecturally correct one.

## Test plan

- [ ] Generate a Hyperframes doc via the `video-hyperframes` skill in the editor *(UI smoke — manual)*
- [ ] Open Export menu, confirm the "Hyperframes · N frames" section appears *(UI smoke — manual)*
- [x] Click "Remotion project (.zip)", confirm a zip downloads with the expected structure (`package.json`, `src/`, `public/frames/frame-NN.html`, `README.md`, `hyperframes.html`, `hyperframes.meta.json`) — verified end-to-end via headless `exportRemotionZip` call against the bundled `example.html`; all expected files present in the zip.
- [x] Unzip, run `npm install && npx remotion studio` — composition should preview correctly — `npm install` ✅; the composition bundles correctly (the render path below uses the same bundler). Live Studio preview not run interactively.
- [x] `npx remotion render Hyperframes out/video.mp4` — verify mp4 plays back with correct frame timings + fade transitions — rendered 816/816 frames + encoded → 1.2 MB H.264 1920×1080 @ 30 fps, **27.20 s**, matching the precomputed `compositionFrames = 900 − 7×12 = 816`. Confirms TransitionSeries cross-fade math end-to-end.
- [ ] Verify section is hidden when the active doc is NOT a Hyperframes output (e.g. a Deck, plain HTML) *(UI smoke — manual)*
- [x] Run `tsc --noEmit` — clean on both source repo AND the emitted project under its own `strict: true` config. `next build` also passes.
