### PR TITLE
fix(deploy): stable selector reference to prevent infinite render loop

### DIFF
--- a/src/components/deploy-control.tsx
+++ b/src/components/deploy-control.tsx
@@ -27,11 +27,13 @@ import {
  * "coming soon" placeholder for it.
  */
 
+const EMPTY_DEPLOYMENTS: DeploymentRecord[] = [];
+
 export function DeployControl() {
   const html = useStore((s) => selectActiveTask(s)?.html ?? "");
   const taskId = useStore((s) => s.activeTaskId);
   const deployments = useStore(
-    (s) => selectActiveTask(s)?.deployments ?? [],
+    (s) => selectActiveTask(s)?.deployments ?? EMPTY_DEPLOYMENTS,
   );
   const removeDeploymentFor = useStore((s) => s.removeDeploymentFor);
   const t = useT();


### PR DESCRIPTION
## Summary

- `DeployControl` used an inline `?? []` fallback inside the `useStore` selector
- A new array reference was created on every render, causing `useSyncExternalStore` to detect a change every tick via `Object.is` and loop infinitely
- Fix: extract a module-level `EMPTY_DEPLOYMENTS` constant so the reference is always stable