### PR TITLE
Support Codex 0.130 JSON agent messages

### DIFF
--- a/src/lib/agents/argv.ts
+++ b/src/lib/agents/argv.ts
@@ -299,8 +299,12 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
 
   if (agent === "codex") {
     if (obj.type === "item.completed" && obj.item && typeof obj.item === "object") {
-      const item = obj.item as { item_type?: string; text?: string };
-      if (item.item_type === "assistant_message" && typeof item.text === "string") {
+      const item = obj.item as { item_type?: string; type?: string; text?: string };
+      const itemType = item.item_type ?? item.type;
+      if (
+        (itemType === "assistant_message" || itemType === "agent_message") &&
+        typeof item.text === "string"
+      ) {
         out.push({ kind: "delta", text: item.text });
       }
     }
@@ -314,6 +318,9 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
       }
     }
     if (obj.type === "task_complete" && obj.usage) {
+      out.push({ kind: "meta", key: "usage", value: obj.usage });
+    }
+    if (obj.type === "turn.completed" && obj.usage) {
       out.push({ kind: "meta", key: "usage", value: obj.usage });
     }
   }


### PR DESCRIPTION
## Summary
- Accept both legacy Codex `item.item_type = assistant_message` and current `item.type = agent_message` completed-item payloads.
- Parse Codex `turn.completed.usage` as usage metadata while preserving existing `task_complete` support.

Fixes #23

## Verification
- `pnpm exec tsc --noEmit`
- Direct parser regression script for `assistant_message`, `agent_message`, and `turn.completed.usage`
- `pnpm build` (passes; existing Turbopack NFT tracing warning remains)