### PR TITLE
fix(convert-chip): move early return after all hook calls

### DIFF
--- a/src/components/convert-chip.tsx
+++ b/src/components/convert-chip.tsx
@@ -23,10 +23,6 @@ export function ConvertChip() {
   const { run, cancel } = useConvert();
   const t = useT();
 
-  // Only show in split mode — when only one pane is visible there's no
-  // divider to hang off, and the toolbar button is already obvious.
-  if (layoutMode !== "split") return null;
-
   const agentInfo = agents.find((a) => a.id === agent);
   const model = agent ? agentModels[agent] ?? "default" : "default";
   const canConvert =
@@ -55,6 +51,7 @@ export function ConvertChip() {
   // Lives here (not in Toolbar) because the chip is the single source of
   // Convert truth after the toolbar button was removed.
   useEffect(() => {
+    if (layoutMode !== "split") return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
         if (isRunning || !canConvert) return;
@@ -64,7 +61,11 @@ export function ConvertChip() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClick, isRunning, canConvert]);
+  }, [layoutMode, onClick, isRunning, canConvert]);
+
+  // Only show in split mode — when only one pane is visible there's no
+  // divider to hang off, and the toolbar button is already obvious.
+  if (layoutMode !== "split") return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Early return on `layoutMode !== "split"` was placed before `useCallback`
  and `useEffect`, violating React's Rules of Hooks and causing a runtime
  crash ("Rendered fewer hooks than expected") whenever the layout mode was
  not split.
- Moved all hook calls above the conditional return.
- Added an inline `if (layoutMode !== "split") return` guard inside
  `useEffect` so the ⌘+Enter keydown listener is only registered when the
  chip is actually visible.

## Test plan
- [x] Switch to split mode — ConvertChip renders, ⌘+Enter triggers convert.
- [x] Switch to editor-only or preview-only mode — no crash, chip hidden,
      ⌘+Enter does nothing.
- [x] Hard-reload in each layout mode — no hook-count mismatch error in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)