### PR TITLE
fix(convert-chip): move layout-mode guard after all hooks

### DIFF
--- a/src/components/convert-chip.tsx
+++ b/src/components/convert-chip.tsx
@@ -23,10 +23,6 @@ export function ConvertChip() {
   const { run, cancel } = useConvert();
   const t = useT();
 
-  // Only show in split mode — when only one pane is visible there's no
-  // divider to hang off, and the toolbar button is already obvious.
-  if (layoutMode !== "split") return null;
-
   const agentInfo = agents.find((a) => a.id === agent);
   const model = agent ? agentModels[agent] ?? "default" : "default";
   const canConvert =
@@ -65,6 +61,11 @@ export function ConvertChip() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClick, isRunning, canConvert]);
+
+  // Only show in split mode — when only one pane is visible there's no
+  // divider to hang off, and the toolbar button is already obvious. Must be
+  // after all hooks to keep hook order stable across layout-mode changes.
+  if (layoutMode !== "split") return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- `ConvertChip` had an early `return null` for non-split layouts sitting **between** `useStore`/`useT` and the later `useCallback`/`useEffect` hooks. Toggling `layoutMode` between `split` and `editor`/`preview` therefore changed the hook count between renders, and React threw **"Rendered fewer hooks than expected"** (minified `#300`).
- Moves the layout-mode guard below every hook call so hook order stays stable across layout changes. No behavior change in the rendered UI.

Refs #26 — fixes symptom 1 of 3 (the other two, the deploy-control snapshot loop and the Codex `agent_message` parser drift, are not touched here).

## Test plan
- [x] `pnpm dev`, load `/`, toggle layout between split / editor / preview — no React crash, chip appears only in split mode.
- [x] ⌘/Ctrl+Enter still triggers Convert from the chip while in split mode.
- [ ] `pnpm build` (reviewer to confirm in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)