### PR TITLE
fix(deploy-control): stabilize empty deployments selector

### DIFF
--- a/src/components/deploy-control.tsx
+++ b/src/components/deploy-control.tsx
@@ -9,6 +9,8 @@ import {
   type DeploymentRecord,
 } from "@/lib/store";
 
+const EMPTY_DEPLOYMENTS: readonly DeploymentRecord[] = [];
+
 /**
  * Publish-to-Vercel control rendered next to the preview-pane toolbar
  * actions. Renders three things in one rounded popover-anchor block:
@@ -31,7 +33,7 @@ export function DeployControl() {
   const html = useStore((s) => selectActiveTask(s)?.html ?? "");
   const taskId = useStore((s) => s.activeTaskId);
   const deployments = useStore(
-    (s) => selectActiveTask(s)?.deployments ?? [],
+    (s) => selectActiveTask(s)?.deployments ?? EMPTY_DEPLOYMENTS,
   );
   const removeDeploymentFor = useStore((s) => s.removeDeploymentFor);
   const t = useT();


### PR DESCRIPTION
## Summary
- `DeployControl` selector `(s) => selectActiveTask(s)?.deployments ?? []` allocated a fresh `[]` on every render when the active task had no `deployments`, so zustand's default `Object.is` snapshot comparison saw a new value each time.
- That triggered the React warnings `getSnapshot should be cached to avoid an infinite loop` and `Maximum update depth exceeded`, surfacing in the preview pane the moment `<DeployControl />` mounted for a task without prior deployments.
- Fix: hoist a module-level `EMPTY_DEPLOYMENTS: readonly DeploymentRecord[]` constant and return it from the selector so the snapshot reference is stable.

## Test plan
- [ ] Open a fresh task (no prior deploys) and confirm `<DeployControl />` renders without the React error overlay.
- [ ] Run a deploy → verify the success row + history dropdown still work, and the deployments count updates as before.
- [ ] Switch between tasks (one with deploys, one without) and confirm no render loop is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)