### PR TITLE
fix(deploy): resolve infinite re-render in DeployControl

### DIFF
--- a/src/components/deploy-control.tsx
+++ b/src/components/deploy-control.tsx
@@ -9,6 +9,8 @@ import {
   type DeploymentRecord,
 } from "@/lib/store";
 
+const EMPTY_DEPLOYMENTS: DeploymentRecord[] = [];
+
 /**
  * Publish-to-Vercel control rendered next to the preview-pane toolbar
  * actions. Renders three things in one rounded popover-anchor block:
@@ -31,7 +33,7 @@ export function DeployControl() {
   const html = useStore((s) => selectActiveTask(s)?.html ?? "");
   const taskId = useStore((s) => s.activeTaskId);
   const deployments = useStore(
-    (s) => selectActiveTask(s)?.deployments ?? [],
+    (s) => selectActiveTask(s)?.deployments ?? EMPTY_DEPLOYMENTS,
   );
   const removeDeploymentFor = useStore((s) => s.removeDeploymentFor);
   const t = useT();


### PR DESCRIPTION
## Summary
- Fix "Maximum update depth exceeded" crash caused by unstable `[]` fallback in the `deployments` Zustand selector in `DeployControl`
- Replace with a module-level stable empty array constant (`EMPTY_DEPLOYMENTS`), matching the existing pattern used for `EMPTY_LOG` and `EMPTY_STATS` in `preview-pane.tsx`

## Root Cause
`useStore((s) => selectActiveTask(s)?.deployments ?? [])` creates a new `[]` reference on every render. Zustand detects the reference change, re-renders the component, which creates another new `[]`, causing an infinite loop.

## Test plan
- [ ] Run `pnpm dev` and open the app
- [ ] Verify no "getSnapshot should be cached" or "Maximum update depth exceeded" errors in the browser console
- [ ] Verify DeployControl still renders correctly after a Convert completes
- [ ] Verify deployment history dropdown still works