### PR TITLE
fix(deploy): prevent infinite loop in zustand selector

### DIFF
--- a/src/components/deploy-control.tsx
+++ b/src/components/deploy-control.tsx
@@ -9,6 +9,9 @@ import {
   type DeploymentRecord,
 } from "@/lib/store";
 
+// Stable empty array reference to prevent infinite loops when no deployments exist.
+const EMPTY_DEPLOYMENTS: DeploymentRecord[] = [];
+
 /**
  * Publish-to-Vercel control rendered next to the preview-pane toolbar
  * actions. Renders three things in one rounded popover-anchor block:
@@ -30,9 +33,12 @@ import {
 export function DeployControl() {
   const html = useStore((s) => selectActiveTask(s)?.html ?? "");
   const taskId = useStore((s) => s.activeTaskId);
-  const deployments = useStore(
-    (s) => selectActiveTask(s)?.deployments ?? [],
-  );
+  // Pull deployments directly from tasks to avoid selector re-creation on every render.
+  // Using a stable empty array reference prevents infinite loops when no deployments exist.
+  const deployments = useStore((s) => {
+    const task = s.tasks.find((t) => t.id === s.activeTaskId);
+    return task?.deployments ?? EMPTY_DEPLOYMENTS;
+  });
   const removeDeploymentFor = useStore((s) => s.removeDeploymentFor);
   const t = useT();
   const { status, error, latest, deploy } = useDeploy();


### PR DESCRIPTION
## 🐛 Bug Description

**Error Message:**
```
The result of getSnapshot should be cached to avoid an infinite loop
    at DeployControl (src/components/deploy-control.tsx:33:31)
    at PreviewPane (src/components/preview-pane.tsx:283:15)
    at Home (src/app/page.tsx:91:15)
```

The `DeployControl` component enters an infinite render loop when the active task has no deployment records.

---

## 🔍 Root Cause

In `src/components/deploy-control.tsx:33-35`:

```tsx
const deployments = useStore(
  (s) => selectActiveTask(s)?.deployments ?? [],
);
```

**The issue:**
- `selectActiveTask(s)` returns a Task object reference that may change on every render
- When `deployments` is `undefined`, the `?? []` expression creates a **new empty array** on each render
- React's zustand hook detects the array reference change → triggers re-render
- Re-render runs the selector again → creates another new empty array → infinite loop

---

## ✅ Solution

**Changes in `src/components/deploy-control.tsx`:**

1. Added a stable empty array constant:
   ```tsx
   const EMPTY_DEPLOYMENTS: DeploymentRecord[] = [];
   ```

2. Refactored the selector to:
   - Directly find the task from `s.tasks` instead of nesting `selectActiveTask()` call
   - Use the stable `EMPTY_DEPLOYMENTS` constant instead of creating `[]` inline

   ```tsx
   const deployments = useStore((s) => {
     const task = s.tasks.find((t) => t.id === s.activeTaskId);
     return task?.deployments ?? EMPTY_DEPLOYMENTS;
   });
   ```

**Why this works:**
- `EMPTY_DEPLOYMENTS` is a module-level constant with a stable reference
- Even when deployments is `undefined`, we return the same array reference every time
- zustand can properly cache the selector result

---

## 🧪 Test Plan

- [x] Verified error is resolved after hot-reload
- [x] `DeployControl` renders correctly when task has no deployments
- [x] `DeployControl` renders correctly when task has existing deployments
- [x] Deployment history dropdown opens and closes without errors

---

## 📸 Before/After

**Before:** Console error + frozen UI
```
Error: The result of getSnapshot should be cached to avoid an infinite loop
```

**After:** Clean render, no errors

---

## 🔗 Related

- zustand documentation: https://github.com/pmndrs/zustand#selecting-multiple-state-slices
- Similar issue patterns: https://github.com/pmndrs/zustand/issues/1979

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)