### PR TITLE
fix(gallery): prevent load button text wrapping in card footer

### DIFF
--- a/src/components/formats-gallery.tsx
+++ b/src/components/formats-gallery.tsx
@@ -478,14 +478,14 @@ function FormatCard({ ex, onLoad }: { ex: FormatExample; onLoad: () => void }) {
         </pre>
         <div className="flex items-center justify-between gap-2 pt-1 mt-auto">
           <span
-            className="text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)] truncate"
+            className="min-w-0 truncate text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]"
             title={ex.filename}
           >
             {ex.filename}
           </span>
           <button
             onClick={onLoad}
-            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-semibold transition-all"
+            className="shrink-0 whitespace-nowrap inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-semibold transition-all"
             style={{
               background: "var(--coral)",
               color: "#fff",

--- a/src/components/samples-gallery.tsx
+++ b/src/components/samples-gallery.tsx
@@ -281,7 +281,10 @@ function SampleCard({
         )}
 
         <div className="flex items-center justify-between gap-2 pt-1.5 mt-auto">
-          <span className="min-w-0 truncate text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]">
+          <span
+            className="min-w-0 truncate text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]"
+            title={`${tpl.scenario} · ${example?.format ?? "html"}`}
+          >
             {tpl.scenario} · {example?.format ?? "html"}
           </span>
           <button

--- a/src/components/samples-gallery.tsx
+++ b/src/components/samples-gallery.tsx
@@ -281,13 +281,13 @@ function SampleCard({
         )}
 
         <div className="flex items-center justify-between gap-2 pt-1.5 mt-auto">
-          <span className="text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]">
+          <span className="min-w-0 truncate text-[10px] uppercase tracking-[0.14em] text-[var(--ink-faint)]">
             {tpl.scenario} · {example?.format ?? "html"}
           </span>
           <button
             onClick={onLoad}
             disabled={loading}
-            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-semibold transition-all disabled:opacity-50"
+            className="shrink-0 whitespace-nowrap inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-semibold transition-all disabled:opacity-50"
             style={{
               background: "var(--coral)",
               color: "#fff",


### PR DESCRIPTION
## Summary

  - In both `FormatCard` (formats gallery) and `SampleCard` (samples gallery),
    the load button ("✨ 载入 →" / "✨ 载入并预览 →") was wrapping its label
    to a second line, inflating the card footer height from ~30 px to ~48 px.
  - Root cause: the filename/scenario `<span>` had no `min-w-0`, so it consumed
    all available flex space and left the button too narrow to fit its text on
    one line.

  ## Changes

  - `src/components/formats-gallery.tsx` (`FormatCard`): add `min-w-0 truncate`
    to the label span; add `shrink-0 whitespace-nowrap` to the load button.
  - `src/components/samples-gallery.tsx` (`SampleCard`): same two-line fix.

  ## Before / After

  Before: button text wraps to 2 lines, footer height ≈ 48 px
  
<img width="279" height="250" alt="image" src="https://github.com/user-attachments/assets/626a9e50-8f33-4623-a082-c4bb8b3b2bc9" />

  After: button text stays on 1 line, footer height ≈ 30 px (confirmed via CDP)
<img width="253" height="222" alt="image" src="https://github.com/user-attachments/assets/474437d7-5798-4931-baf7-a55e01aaf6e0" />

  ## Test plan

  - [x] Opened formats gallery ("格式" tab) — all 11 cards show single-line buttons
  - [x] Opened samples gallery ("示例" tab) — sampled 3 cards, all buttons 30 px tall
  - [x] Verified via `getBoundingClientRect()` in Chrome DevTools