### PR TITLE
fix(deploy): public-by-default Vercel previews + toolbar Publish UX + Clear button fix

### DIFF
--- a/src/app/api/deploy/config/route.ts
+++ b/src/app/api/deploy/config/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
+  clearDeployConfig,
   DeployError,
   isDeployProviderId,
   publicDeployConfigForProvider,
@@ -13,11 +14,13 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * GET  /api/deploy/config?provider=vercel
+ * GET    /api/deploy/config?provider=vercel
  *   → public-shape config (token masked)
- * PUT  /api/deploy/config?provider=vercel
+ * PUT    /api/deploy/config?provider=vercel
  *   body: { token?, teamId?, teamSlug?, accountId? }
  *   → updated public-shape config
+ * DELETE /api/deploy/config?provider=vercel
+ *   → unconfigured public-shape config (deletes the on-disk credential file)
  *
  * Tokens never leave the server in plaintext. Once configured, GET returns
  * `tokenMask: "saved-vercel-token"` (or the cloudflare equivalent); the
@@ -68,6 +71,16 @@ export async function PUT(req: NextRequest) {
     }
     const updated = await writeDeployConfig(providerId, body);
     return NextResponse.json(updated);
+  } catch (err) {
+    return deployErrorResponse(err);
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const providerId = readProvider(req);
+    const cleared = await clearDeployConfig(providerId);
+    return NextResponse.json(cleared);
   } catch (err) {
     return deployErrorResponse(err);
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { EditorPane } from "@/components/editor-pane";
 import { PreviewPane } from "@/components/preview-pane";
 import { TasksSidebar } from "@/components/tasks-sidebar";
 import { WelcomeModal } from "@/components/welcome-modal";
-import { SettingsModal } from "@/components/settings-modal";
+import { SettingsModal, type SectionId } from "@/components/settings-modal";
 import { ConvertChip } from "@/components/convert-chip";
 import { useStore, type AgentInfo } from "@/lib/store";
 
@@ -19,6 +19,10 @@ export default function Home() {
   const layoutMode = useStore((s) => s.layoutMode);
   const [welcomeOpen, setWelcomeOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsInitialSection, setSettingsInitialSection] = useState<
+    SectionId | undefined
+  >(undefined);
+  const [deployConfigRev, setDeployConfigRev] = useState(0);
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
@@ -67,6 +71,11 @@ export default function Home() {
         iframeRef={iframeRef}
         onOpenAgentPicker={() => setSettingsOpen(true)}
         onOpenSettings={() => setSettingsOpen(true)}
+        onRequestConfigureDeploy={() => {
+          setSettingsInitialSection("deploy");
+          setSettingsOpen(true);
+        }}
+        deployConfigRev={deployConfigRev}
       />
       <div
         className="flex flex-1 min-h-0"
@@ -95,7 +104,16 @@ export default function Home() {
         </div>
       </div>
       {welcomeOpen && <WelcomeModal onClose={() => setWelcomeOpen(false)} />}
-      {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
+      {settingsOpen && (
+        <SettingsModal
+          initialSection={settingsInitialSection}
+          onClose={() => {
+            setSettingsOpen(false);
+            setSettingsInitialSection(undefined);
+            setDeployConfigRev((r) => r + 1);
+          }}
+        />
+      )}
     </main>
   );
 }

--- a/src/components/deploy-control.tsx
+++ b/src/components/deploy-control.tsx
@@ -29,7 +29,13 @@ const EMPTY_DEPLOYMENTS: readonly DeploymentRecord[] = [];
  * "coming soon" placeholder for it.
  */
 
-export function DeployControl() {
+export function DeployControl({
+  onRequestConfigureDeploy,
+  configRev = 0,
+}: {
+  onRequestConfigureDeploy: () => void;
+  configRev?: number;
+}) {
   const html = useStore((s) => selectActiveTask(s)?.html ?? "");
   const taskId = useStore((s) => s.activeTaskId);
   const deployments = useStore(
@@ -40,7 +46,27 @@ export function DeployControl() {
   const { status, error, latest, deploy } = useDeploy();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  // null = unknown (still loading), true/false = checked state. Probed via
+  // the same /api/deploy/config endpoint Settings → Deploy reads, so the
+  // toolbar Publish button knows whether to deploy or steer the user to
+  // configure a token first.
+  const [configured, setConfigured] = useState<boolean | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/deploy/config?provider=vercel")
+      .then((r) => r.json())
+      .then((d: { configured?: boolean }) => {
+        if (!cancelled) setConfigured(!!d?.configured);
+      })
+      .catch(() => {
+        if (!cancelled) setConfigured(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [configRev]);
 
   // Close the history dropdown on outside click.
   useEffect(() => {
@@ -62,10 +88,19 @@ export function DeployControl() {
   }, [copiedUrl]);
 
   const isDeploying = status === "deploying";
-  const canDeploy = html.length > 0 && !isDeploying;
+  const isUnconfigured = configured === false;
+  // The button is clickable in two cases: a normal deploy (configured + has html),
+  // or an unconfigured-state click that steers the user to Settings. Anything else
+  // (deploying, or configured-but-no-html) disables the button.
+  const disabled = isDeploying || (!isUnconfigured && html.length === 0);
 
   const onClickPublish = () => {
-    if (!canDeploy) return;
+    if (isDeploying) return;
+    if (isUnconfigured) {
+      onRequestConfigureDeploy();
+      return;
+    }
+    if (html.length === 0) return;
     void deploy({ taskId, provider: "vercel", html });
   };
 
@@ -86,18 +121,14 @@ export function DeployControl() {
     <div ref={popoverRef} className="relative inline-flex items-center gap-1.5">
       <button
         onClick={onClickPublish}
-        disabled={!canDeploy}
-        title={canDeploy ? undefined : t("deploy.button.disabled")}
-        className="rounded-full px-3 py-0.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
-        style={{
-          background: isDeploying ? "var(--coral)" : "var(--ink)",
-          color: "#fff",
-          border: "1px solid transparent",
-        }}
+        disabled={disabled}
+        title={disabled ? t("deploy.button.disabled") : undefined}
+        className="btn-ink"
+        style={isDeploying ? { background: "var(--coral)" } : undefined}
       >
         {isDeploying ? (
           <>
-            <span className="mr-1 inline-block h-2 w-2 animate-pulse rounded-full bg-white align-middle" />
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white align-middle" />
             {t("deploy.deploying")}
           </>
         ) : (

--- a/src/components/preview-pane.tsx
+++ b/src/components/preview-pane.tsx
@@ -6,7 +6,6 @@ import { useT, type DictKey } from "@/lib/i18n";
 import { previewHtml, extractHtml } from "@/lib/extract-html";
 import { isDeck } from "@/lib/deck";
 import { DeckViewer } from "./deck-viewer";
-import { DeployControl } from "./deploy-control";
 
 type PreviewTab = "preview" | "deck" | "code" | "log";
 
@@ -276,11 +275,6 @@ export function PreviewPane({
               >
                 {t("preview.present")} <span className="opacity-50">F</span>
               </button>
-            )}
-            {/* Publish-to-Vercel button — only meaningful once a Convert has
-                produced html, and only on tabs that show the user that html. */}
-            {(tab === "preview" || tab === "code") && status === "done" && html && (
-              <DeployControl />
             )}
             <StatusPill status={status} />
           </div>

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -12,7 +12,7 @@ import { useT, type DictKey } from "@/lib/i18n";
 
 type Props = { onClose: () => void; initialSection?: SectionId };
 
-type SectionId = "agent" | "deploy" | "language";
+export type SectionId = "agent" | "deploy" | "language";
 
 const SECTIONS: Array<{ id: SectionId; labelKey: DictKey; hintKey: DictKey }> = [
   { id: "agent", labelKey: "settings.section.agent.label", hintKey: "settings.section.agent.hint" },

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -633,23 +633,18 @@ function VercelDeployConfig() {
     setLoading(true);
     setErr(null);
     try {
-      // Empty token would re-throw on the server (token required); use a
-      // workaround by writing an empty token directly to disk via PUT —
-      // the server validates non-empty, so for now Clear == manual edit.
-      // We surface this by hitting PUT with an empty token and accepting
-      // the error, then resetting UI. See follow-up TODO in deploy/config.ts.
       const res = await fetch("/api/deploy/config?provider=vercel", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: "", teamSlug: "" }),
+        method: "DELETE",
       });
-      // Even on 400 we want UI to reset locally; the file persists until the
-      // user provides a non-empty token to overwrite.
-      void res;
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
       setToken("");
       setTeamSlug("");
       setConfigured(false);
       setTokenMask("");
+      setSavedAt(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -5,15 +5,20 @@ import { useT } from "@/lib/i18n";
 import { TemplatePicker } from "./template-picker";
 import { ExportMenu } from "./export-menu";
 import { LayoutModeToggle } from "./layout-mode-toggle";
+import { DeployControl } from "./deploy-control";
 
 export function Toolbar({
   iframeRef,
   onOpenAgentPicker,
   onOpenSettings,
+  onRequestConfigureDeploy,
+  deployConfigRev,
 }: {
   iframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
   onOpenAgentPicker: () => void;
   onOpenSettings: () => void;
+  onRequestConfigureDeploy: () => void;
+  deployConfigRev: number;
 }) {
   const agent = useStore((s) => s.selectedAgent);
   const agents = useStore((s) => s.agents);
@@ -81,6 +86,10 @@ export function Toolbar({
             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
+        <DeployControl
+          onRequestConfigureDeploy={onRequestConfigureDeploy}
+          configRev={deployConfigRev}
+        />
         <ExportMenu iframeRef={iframeRef} />
       </div>
     </header>

--- a/src/lib/deploy/config.ts
+++ b/src/lib/deploy/config.ts
@@ -218,6 +218,21 @@ export async function writeDeployConfig(
     : writeVercelConfig(input);
 }
 
+// `writeDeployConfig` requires a non-empty token, so it can't be used to clear
+// a previously saved configuration — Settings → Clear has to delete the file
+// outright. ENOENT means it was already gone, which we treat as success so the
+// UI ends up in the same "unconfigured" state either way.
+export async function clearDeployConfig(
+  providerId: DeployProviderId,
+): Promise<PublicDeployConfig> {
+  try {
+    await fsp.unlink(deployConfigPath(providerId));
+  } catch (err) {
+    if (!isEnoent(err)) throw err;
+  }
+  return publicDeployConfigForProvider(providerId, {});
+}
+
 export function publicVercelConfig(
   config: Partial<DeployConfig>,
 ): PublicDeployConfig {

--- a/src/lib/deploy/vercel.ts
+++ b/src/lib/deploy/vercel.ts
@@ -38,6 +38,7 @@ type VercelJson = Record<string, unknown> & {
   alias?: string[] | unknown[];
   aliases?: string[] | unknown[];
   readyState?: string;
+  projectId?: string;
   error?: { code?: string; message?: string };
   message?: string;
 };
@@ -103,6 +104,39 @@ function deploymentUrlCandidates(...responses: Array<VercelJson | null>): string
     }
   }
   return [...new Set(urls.map(normalizeDeploymentUrl).filter(Boolean))];
+}
+
+// Hobby projects default to Vercel Authentication on every preview, so the
+// *.vercel.app URL 401s for anyone not signed into the deploying account.
+// html-anything's whole UX is "share this link" — opt the freshly created
+// project out of protection. Failure here is non-fatal: url-check will still
+// surface a `protected` status with instructions if the link really is locked.
+async function disableVercelDeploymentProtection(
+  config: DeployConfig,
+  projectId: string,
+): Promise<void> {
+  const resp = await fetch(
+    `${VERCEL_API}/v9/projects/${encodeURIComponent(projectId)}${vercelTeamQuery(config)}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ssoProtection: null }),
+    },
+  );
+  if (resp.ok) return;
+  let detail = `HTTP ${resp.status}`;
+  try {
+    const json = (await resp.json()) as VercelJson;
+    detail = json?.error?.message || json?.message || detail;
+  } catch {
+    /* ignore */
+  }
+  console.warn(
+    `[deployToVercel] failed to disable Vercel SSO protection: ${detail}`,
+  );
 }
 
 async function pollVercelDeployment(
@@ -182,6 +216,19 @@ export async function deployToVercel({
 
   const deploymentId = String(created.id || created.uid || "");
   const initialUrl = deploymentUrl(created);
+
+  const projectId =
+    typeof created.projectId === "string" ? created.projectId : "";
+  if (projectId) {
+    await disableVercelDeploymentProtection(config, projectId).catch((err) => {
+      console.warn(
+        `[deployToVercel] disableVercelDeploymentProtection threw: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+
   const ready = deploymentId
     ? await pollVercelDeployment(config, deploymentId)
     : created;


### PR DESCRIPTION
Three related changes to the one-click Vercel publish flow.

## 1. `fix(deploy)`: make freshly deployed Vercel previews publicly viewable

New Vercel projects on Hobby plans default to Vercel Authentication on every preview, so the `*.vercel.app` URL returns HTTP 401 to anyone not signed into the deploying account. html-anything's deploy UX is "share this link" — surface a public URL by PATCHing the new project's `ssoProtection` to `null` right after the deployment is created.

Failure is non-fatal: the existing `url-check.ts` `protected` branch still surfaces remediation instructions to the UI if the link really is locked.

**Repro before the fix**: deploy any task with a fresh Vercel token under a Hobby team → open the returned URL in an incognito window → 401 + "Authentication Required".

## 2. `feat(deploy)`: hoist Publish button into the header and onboard unconfigured users

- Move `<DeployControl />` from the preview-pane action area into the top toolbar, between the Settings gear and the Export menu. The button now renders on every tab regardless of conversion state — the existing `disabled` guard already covers "no html yet", and hiding the entry point made the feature easy to miss.
- When the Vercel API token isn't configured yet, clicking Publish opens the Settings modal pre-focused on the Deploy section instead of firing a deploy that would only fail server-side. `SettingsModal` already accepted an `initialSection` prop, so the wiring is just exporting `SectionId` from settings-modal and threading an `onRequestConfigureDeploy` callback through `page` → `toolbar` → `deploy-control`. Closing the modal bumps a `deployConfigRev` counter so `DeployControl` re-fetches `/api/deploy/config` and re-evaluates its configured state without a full reload.
- Match the Publish button's height to the neighboring `btn-ink` controls (Export, Settings) for a single-row toolbar.

## 3. `fix(deploy)`: make Settings → Clear actually delete the saved token

`writeVercelConfig` short-circuits to the existing token whenever the incoming token field is empty, so partial-update of `teamId` / `teamSlug` preserves the saved credential. The previous Clear workaround — PUTting `{ token: "" }` — silently kept the old token on disk and reset only the local UI state; re-opening Settings showed `saved-vercel-token` again immediately.

Add a `DELETE` handler on `/api/deploy/config` that unlinks the provider's config file via a new `clearDeployConfig(providerId)` helper (ENOENT treated as success for idempotency), and switch Settings → Clear to call it. `PUT` semantics are unchanged so partial updates of non-token fields remain safe.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [ ] Toolbar visual: Publish button sits between Settings and Export, equal height
- [ ] No active task / no html: Publish renders disabled with title
- [ ] Unconfigured: clicking Publish opens Settings on Deploy section; closing the modal after saving a token re-evaluates DeployControl state without reload
- [ ] Configured + html: Publish triggers a real deploy; the resulting `*.vercel.app` URL is reachable from an incognito window without signing in
- [ ] Settings → Clear: reopening Settings shows the Vercel section as Unconfigured; the file `~/.html-anything/vercel.json` is removed from disk