### PR TITLE
fix(convert-chip): fix hooks order when toggling layout mode

### DIFF
--- a/src/components/convert-chip.tsx
+++ b/src/components/convert-chip.tsx
@@ -23,10 +23,6 @@ export function ConvertChip() {
   const { run, cancel } = useConvert();
   const t = useT();
 
-  // Only show in split mode — when only one pane is visible there's no
-  // divider to hang off, and the toolbar button is already obvious.
-  if (layoutMode !== "split") return null;
-
   const agentInfo = agents.find((a) => a.id === agent);
   const model = agent ? agentModels[agent] ?? "default" : "default";
   const canConvert =
@@ -65,6 +61,10 @@ export function ConvertChip() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClick, isRunning, canConvert]);
+
+  // Only show in split mode — when only one pane is visible there's no
+  // divider to hang off, and the toolbar button is already obvious.
+  if (layoutMode !== "split") return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Fixes `Rendered fewer hooks than expected` when switching layout between split / editor / preview.
- Moves `if (layoutMode !== "split") return null` to after `useCallback` and `useEffect` in `ConvertChip`.

## Test plan
- [ ] `pnpm dev`, open the app
- [ ] Toggle layout: split → editor → preview → split; no hook errors in console
- [ ] Convert chip visible only in split mode
- [ ] ⌘/Ctrl+Enter still triggers convert when enabled