### PR TITLE
[codex] fix Codex JSON parsing and convert chip hooks

### DIFF
--- a/src/components/convert-chip.tsx
+++ b/src/components/convert-chip.tsx
@@ -23,10 +23,6 @@ export function ConvertChip() {
   const { run, cancel } = useConvert();
   const t = useT();
 
-  // Only show in split mode — when only one pane is visible there's no
-  // divider to hang off, and the toolbar button is already obvious.
-  if (layoutMode !== "split") return null;
-
   const agentInfo = agents.find((a) => a.id === agent);
   const model = agent ? agentModels[agent] ?? "default" : "default";
   const canConvert =
@@ -65,6 +61,10 @@ export function ConvertChip() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClick, isRunning, canConvert]);
+
+  // Only show in split mode — when only one pane is visible there's no
+  // divider to hang off, and the toolbar button is already obvious.
+  if (layoutMode !== "split") return null;
 
   return (
     <div

--- a/src/lib/agents/argv.ts
+++ b/src/lib/agents/argv.ts
@@ -299,8 +299,11 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
 
   if (agent === "codex") {
     if (obj.type === "item.completed" && obj.item && typeof obj.item === "object") {
-      const item = obj.item as { item_type?: string; text?: string };
-      if (item.item_type === "assistant_message" && typeof item.text === "string") {
+      const item = obj.item as { item_type?: string; type?: string; text?: string };
+      if (
+        (item.item_type === "assistant_message" || item.type === "agent_message") &&
+        typeof item.text === "string"
+      ) {
         out.push({ kind: "delta", text: item.text });
       }
     }
@@ -313,7 +316,7 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
         out.push({ kind: "delta", text: msg.message });
       }
     }
-    if (obj.type === "task_complete" && obj.usage) {
+    if ((obj.type === "task_complete" || obj.type === "turn.completed") && obj.usage) {
       out.push({ kind: "meta", key: "usage", value: obj.usage });
     }
   }


### PR DESCRIPTION
## What changed

- Fix Codex JSON parsing for newer `codex exec --json` events where assistant output arrives as `item.type: "agent_message"` instead of the older `item_type: "assistant_message"` shape.
- Preserve Codex usage parsing for the newer `turn.completed` event.
- Move `ConvertChip`'s split-layout early return below its hooks so React hook ordering remains stable when layout state changes.

## Why

Newer Codex CLI versions can complete successfully while HTML Anything still shows a 0 KB output because the parser ignores the updated event shape. Separately, switching layouts can trigger React's “Rendered fewer hooks than expected” error because `ConvertChip` returned before later hooks ran.

## Validation

- `codex exec --json --skip-git-repo-check --sandbox workspace-write -c sandbox_workspace_write.network_access=true 'Reply with exactly: CODEX_OK'` returned `CODEX_OK`.
- `/api/convert` with `agent: "codex"` returned a complete `<!DOCTYPE html>...` document.
- Browser UI generation with OpenAI Codex completed and produced a 7.0 KB preview.
- `pnpm build` passed. Turbopack still reports the existing NFT tracing warning from `next.config.ts -> src/lib/agents/invoke.ts -> src/app/api/draft/route.ts`.
