### PR TITLE
Point Discord links to html-anything channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <!-- This project is built on top of nexu-io/open-design — the badges below link to its community channels on purpose. -->
 <p align="center">
-  <a href="https://discord.com/invite/qhbcCH8Am4"><img alt="Discord (open-design)" src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" /></a>
+  <a href="https://discord.gg/keeVPMrueT"><img alt="Discord (html-anything)" src="https://img.shields.io/badge/discord-html--anything-5865f2?style=flat-square&logo=discord&logoColor=white" /></a>
   <a href="https://x.com/nexudotio"><img alt="Follow @nexudotio on X" src="https://img.shields.io/badge/follow-%40nexudotio-000000?style=flat-square&logo=x&logoColor=white" /></a>
   <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="open-design release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&label=release&color=8e44ad" /></a>
   <a href="https://github.com/nexu-io/open-design/graphs/commit-activity"><img alt="open-design commits / month" src="https://img.shields.io/github/commit-activity/m/nexu-io/open-design?style=flat-square&label=commits%2Fmonth&color=f39c12" /></a>
@@ -454,7 +454,7 @@ Each bundled upstream skill retains its original LICENSE and authorship inside i
 
 ## Stay in the loop
 
-Follow [**@nexudotio**](https://x.com/nexudotio) on X for release notes, new skills, and the occasional behind-the-scenes thread on what's shipping next. The [Discord](https://discord.com/invite/qhbcCH8Am4) is where the bigger conversations happen — both are run by the upstream `open-design` team, and HTML Anything piggybacks on the same channels.
+Follow [**@nexudotio**](https://x.com/nexudotio) on X for release notes, new skills, and the occasional behind-the-scenes thread on what's shipping next. The [HTML Anything Discord channel](https://discord.gg/keeVPMrueT) is where demos, template requests, export/debugging questions, and bigger community conversations happen — run by the upstream `open-design` team.
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 
 <!-- 本项目站在 nexu-io/open-design 的肩膀上 — 下面这一行的社群标签都指向它,顺道带流量。 -->
 <p align="center">
-  <a href="https://discord.com/invite/qhbcCH8Am4"><img alt="Discord（open-design）" src="https://img.shields.io/badge/discord-join-5865f2?style=flat-square&logo=discord&logoColor=white" /></a>
+  <a href="https://discord.gg/keeVPMrueT"><img alt="Discord（html-anything）" src="https://img.shields.io/badge/discord-html--anything-5865f2?style=flat-square&logo=discord&logoColor=white" /></a>
   <a href="https://x.com/nexudotio"><img alt="X 关注 @nexudotio" src="https://img.shields.io/badge/follow-%40nexudotio-000000?style=flat-square&logo=x&logoColor=white" /></a>
   <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="open-design 最新版本" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&label=release&color=8e44ad" /></a>
   <a href="https://github.com/nexu-io/open-design/graphs/commit-activity"><img alt="open-design 月提交数" src="https://img.shields.io/github/commit-activity/m/nexu-io/open-design?style=flat-square&label=commits%2Fmonth&color=f39c12" /></a>
@@ -350,7 +350,7 @@ picker 用两个维度组织：
 
 ## 📣 关注我们
 
-X 上关注 [**@nexudotio**](https://x.com/nexudotio),看版本发布、新 skill、新 design system,以及偶尔的 behind-the-scenes 线程。[Discord](https://discord.com/invite/qhbcCH8Am4) 是更长篇讨论的场子 —— 两者都由上游 `open-design` 团队维护,HTML Anything 共用同一个社群入口。
+X 上关注 [**@nexudotio**](https://x.com/nexudotio),看版本发布、新 skill、新 design system,以及偶尔的 behind-the-scenes 线程。[HTML Anything Discord 频道](https://discord.gg/keeVPMrueT) 用来展示 demo、提模板需求、排查导出/agent 问题,也承接更长篇的社区讨论 —— 由上游 `open-design` 团队维护。
 
 ## 👥 贡献者
 

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -120,7 +120,7 @@ function CommunityLinks() {
         </svg>
       </a>
       <a
-        href="https://discord.com/invite/qhbcCH8Am4"
+        href="https://discord.gg/keeVPMrueT"
         target="_blank"
         rel="noreferrer noopener"
         className={linkCls}

--- a/src/components/welcome-modal.tsx
+++ b/src/components/welcome-modal.tsx
@@ -243,7 +243,7 @@ export function WelcomeModal({ onClose }: Props) {
             ★ GitHub
           </a>
           <a
-            href="https://discord.com/invite/qhbcCH8Am4"
+            href="https://discord.gg/keeVPMrueT"
             target="_blank"
             rel="noreferrer noopener"
             className="rounded-full px-3 py-1 border transition-colors hover:text-[var(--ink)] hover:border-[var(--ink)]/30"


### PR DESCRIPTION
## Summary
- create a dedicated html-anything Discord destination for repo and app community links
- update README / README.zh-CN badges and stay-in-the-loop copy
- update toolbar and welcome-modal Discord links to the new channel invite

## Validation
- pnpm build

## Discord
- Channel: https://discord.com/channels/1479002485040480266/1505498369504710696
- Invite: https://discord.gg/keeVPMrueT