### PR TITLE
fix deploy success dismissal

### DIFF
--- a/e2e/ui/deploy-control.spec.ts
+++ b/e2e/ui/deploy-control.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const STORE_KEY = "html-everything-store";
+
+const generatedHtml = `<!doctype html>
+<html>
+  <head><title>Deploy Fixture</title></head>
+  <body><main><h1>Deploy Fixture</h1></main></body>
+</html>`;
+
+async function seedStore(page: Page) {
+  const now = 1_700_000_000_000;
+  const task = {
+    id: "task_deploy_ui",
+    name: "Deploy UI fixture",
+    content: "Deploy UI fixture",
+    format: "html",
+    templateId: "article-magazine",
+    html: generatedHtml,
+    status: "done",
+    log: [],
+    stats: { outputBytes: generatedHtml.length, deltaCount: 1 },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await page.addInitScript(
+    ({ key, taskFixture }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          state: {
+            tasks: [taskFixture],
+            activeTaskId: taskFixture.id,
+            selectedAgent: "test-agent",
+            agentModels: {},
+            agentBinOverrides: {},
+            welcomeAck: true,
+            sidebarCollapsed: false,
+            locale: "en",
+            layoutMode: "split",
+          },
+          version: 7,
+        }),
+      );
+    },
+    {
+      key: STORE_KEY,
+      taskFixture: task,
+    },
+  );
+}
+
+test.describe("Deploy control", () => {
+  test("dismisses the latest deploy result without deleting history", async ({
+    page,
+  }) => {
+    await seedStore(page);
+
+    await page.route("**/api/deploy/config?provider=vercel", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ configured: true }),
+      }),
+    );
+    await page.route("**/api/deploy", async (route, request) => {
+      if (request.method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          providerId: "vercel",
+          url: "https://deploy-fixture.vercel.app",
+          deploymentId: "dpl_fixture",
+          target: "production",
+          status: "ready",
+        }),
+      });
+    });
+
+    await page.goto("/");
+
+    const publishButton = page.getByRole("button", { name: /publish/i });
+    await expect(publishButton).toBeEnabled();
+
+    await publishButton.click();
+
+    await expect(page.getByText("Live at")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "https://deploy-fixture.vercel.app" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Dismiss" }).click();
+
+    await expect(page.getByText("Live at")).toHaveCount(0);
+    await page.getByTitle("Past deployments").click();
+    await expect(
+      page.getByRole("link", { name: "https://deploy-fixture.vercel.app" }),
+    ).toBeVisible();
+  });
+});

--- a/next/src/components/deploy-control.tsx
+++ b/next/src/components/deploy-control.tsx
@@ -46,6 +46,9 @@ export function DeployControl({
   const { status, error, latest, deploy } = useDeploy();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const [dismissedLatestId, setDismissedLatestId] = useState<string | null>(
+    null,
+  );
   // null = unknown (still loading), true/false = checked state. Probed via
   // the same /api/deploy/config endpoint Settings → Deploy reads, so the
   // toolbar Publish button knows whether to deploy or steer the user to
@@ -115,7 +118,9 @@ export function DeployControl({
 
   // Newest record first; `latest` may be the same as `deployments[0]` so we
   // dedupe by id to avoid rendering it twice in the result line + history.
-  const visibleHistory = deployments.filter((d) => d.id !== latest?.id);
+  const visibleLatest =
+    latest && latest.id !== dismissedLatestId ? latest : null;
+  const visibleHistory = deployments.filter((d) => d.id !== visibleLatest?.id);
 
   return (
     <div ref={popoverRef} className="relative inline-flex items-center gap-1.5">
@@ -152,7 +157,7 @@ export function DeployControl({
       )}
 
       {/* Inline result row — shown right after a successful deploy. */}
-      {latest && (
+      {visibleLatest && (
         <div
           className="absolute right-0 top-[calc(100%+6px)] z-30 flex max-w-[420px] flex-col gap-1 rounded-xl px-3 py-2 text-[11px] shadow-lg"
           style={{
@@ -166,38 +171,47 @@ export function DeployControl({
               className="h-1.5 w-1.5 rounded-full"
               style={{
                 background:
-                  latest.status === "ready"
+                  visibleLatest.status === "ready"
                     ? "var(--green)"
-                    : latest.status === "protected"
+                    : visibleLatest.status === "protected"
                       ? "var(--coral)"
                       : "var(--amber, #d97706)",
               }}
             />
             <span className="font-medium">
-              {latest.status === "ready"
+              {visibleLatest.status === "ready"
                 ? t("deploy.success.label")
-                : latest.status === "protected"
+                : visibleLatest.status === "protected"
                   ? t("deploy.protected.label")
                   : t("deploy.delayed.label")}
             </span>
+            <button
+              onClick={() => setDismissedLatestId(visibleLatest.id)}
+              aria-label={t("deploy.success.dismiss")}
+              title={t("deploy.success.dismiss")}
+              className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-[12px] hover:bg-[var(--surface)]"
+              style={{ color: "var(--ink-mute)" }}
+            >
+              x
+            </button>
           </div>
           <a
-            href={latest.url}
+            href={visibleLatest.url}
             target="_blank"
             rel="noreferrer noopener"
             className="block max-w-full truncate font-mono text-[11px] text-[var(--coral)] hover:underline"
-            title={latest.url}
+            title={visibleLatest.url}
           >
-            {latest.url}
+            {visibleLatest.url}
           </a>
-          {latest.status !== "ready" && latest.statusMessage && (
+          {visibleLatest.status !== "ready" && visibleLatest.statusMessage && (
             <div className="text-[10.5px] text-[var(--ink-mute)] leading-snug">
-              {latest.statusMessage}
+              {visibleLatest.statusMessage}
             </div>
           )}
           <div className="mt-0.5 flex items-center gap-1.5">
             <button
-              onClick={() => onCopy(latest.url)}
+              onClick={() => onCopy(visibleLatest.url)}
               className="rounded-full px-2 py-0.5 text-[10.5px] hover:bg-[var(--surface)]"
               style={{
                 background: "transparent",
@@ -205,12 +219,12 @@ export function DeployControl({
                 border: "1px solid var(--line)",
               }}
             >
-              {copiedUrl === latest.url
+              {copiedUrl === visibleLatest.url
                 ? t("deploy.success.copied")
                 : `📋 ${t("deploy.success.copy")}`}
             </button>
             <a
-              href={latest.url}
+              href={visibleLatest.url}
               target="_blank"
               rel="noreferrer noopener"
               className="rounded-full px-2 py-0.5 text-[10.5px] no-underline hover:bg-[var(--surface)]"

--- a/next/src/lib/i18n.ts
+++ b/next/src/lib/i18n.ts
@@ -122,6 +122,7 @@ export interface Dict {
   "deploy.success.label": string;
   "deploy.success.copy": string;
   "deploy.success.copied": string;
+  "deploy.success.dismiss": string;
   "deploy.success.open": string;
   "deploy.protected.label": string;
   "deploy.protected.hint": string;
@@ -445,6 +446,7 @@ const en: Dict = {
   "deploy.success.label": "Live at",
   "deploy.success.copy": "Copy",
   "deploy.success.copied": "Copied",
+  "deploy.success.dismiss": "Dismiss",
   "deploy.success.open": "Open",
   "deploy.protected.label": "Deployed (SSO-protected)",
   "deploy.protected.hint":
@@ -765,6 +767,7 @@ const zhCN: Dict = {
   "deploy.success.label": "已发布到",
   "deploy.success.copy": "复制",
   "deploy.success.copied": "已复制",
+  "deploy.success.dismiss": "关闭",
   "deploy.success.open": "打开",
   "deploy.protected.label": "已部署（SSO 保护中）",
   "deploy.protected.hint":


### PR DESCRIPTION
## Summary
- add a dismiss control to the latest deploy success panel
- keep dismissed deployment URLs available in Past deployments instead of deleting them
- cover the publish/dismiss/history flow with a Playwright regression

Fixes #55.

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `npm run test:ui -- deploy-control.spec.ts`
- `npm run test:ui`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

`npm run build` completed successfully with an existing Turbopack NFT tracing warning from the `next.config.ts` import trace; this change does not touch that path.
