### PR TITLE
fix: Qwen Coder responses not rendering — enhance stream-json parser

### DIFF
--- a/src/lib/agents/argv.ts
+++ b/src/lib/agents/argv.ts
@@ -362,10 +362,59 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
     if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
   }
 
-  if (agent === "opencode" || agent === "qwen") {
+  if (agent === "opencode") {
     if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
     if (typeof obj.content === "string") out.push({ kind: "delta", text: obj.content });
     if (typeof obj.message === "string") out.push({ kind: "delta", text: obj.message });
+  }
+
+  if (agent === "qwen") {
+    // Qwen Coder's default output is a stream-json envelope that mirrors
+    // claude's shape (stream_event with content_block_delta/text_delta,
+    // assistant message with tool_use, result with usage).  The old parser
+    // only matched bare `text`/`content`/`message` strings, which caused
+    // every structured JSON line to be classified as noise — the response
+    // appeared in the log pane but never filled into the source panel.
+    // Fixes #58 (Qwen Coder 响应不能自动渲染).
+    if (obj.type === "stream_event" && obj.event && typeof obj.event === "object") {
+      const ev = obj.event as { type?: string; delta?: { type?: string; text?: string; thinking?: string } };
+      if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && typeof ev.delta.text === "string") {
+        state.sawStreamEventText = true;
+        out.push({ kind: "delta", text: ev.delta.text });
+      } else if (ev.type === "content_block_delta" && ev.delta?.type === "thinking_delta") {
+        out.push({ kind: "meta", key: "thinking", value: ev.delta.thinking });
+      }
+    }
+    if (obj.type === "assistant" && obj.message && typeof obj.message === "object") {
+      const msg = obj.message as { content?: Array<{ type?: string; text?: string; name?: string; input?: unknown }> };
+      const toolHtml = rescueHtmlFromToolUse(msg.content);
+      if (toolHtml) {
+        out.push({ kind: "html", text: toolHtml });
+        state.sawStreamEventText = true;
+      }
+      if (!state.sawStreamEventText) {
+        const text = (msg.content ?? [])
+          .filter((c) => c?.type === "text" && typeof c.text === "string")
+          .map((c) => c.text!)
+          .join("");
+        if (text) out.push({ kind: "delta", text });
+      }
+    }
+    if (obj.type === "result") {
+      if (obj.usage) out.push({ kind: "meta", key: "usage", value: obj.usage });
+      if (typeof obj.duration_ms === "number") out.push({ kind: "meta", key: "duration_ms", value: obj.duration_ms });
+      if (typeof obj.total_cost_usd === "number") out.push({ kind: "meta", key: "cost_usd", value: obj.total_cost_usd });
+    }
+    // Fallback bare fields — only when no structured content was emitted
+    if (typeof obj.text === "string" && !state.sawStreamEventText && obj.type !== "assistant") {
+      out.push({ kind: "delta", text: obj.text });
+    }
+    if (typeof obj.content === "string" && !state.sawStreamEventText) {
+      out.push({ kind: "delta", text: obj.content });
+    }
+    if (typeof obj.message === "string" && !state.sawStreamEventText) {
+      out.push({ kind: "delta", text: obj.message });
+    }
   }
 
   if (agent === "qoder") {


### PR DESCRIPTION
## Summary

The Qwen Coder parser in `parseLineWithState` shared a minimal code path with opencode that only matched bare `text`/`content`/`message` string fields. Qwen Coder actually outputs a stream-json envelope like Claude (stream_event with content_block_delta/text_delta, assistant messages with tool_use, result with usage metadata). Every structured JSON line was classified as noise and never filled into the source panel — responses only appeared in the log pane.

## Root Cause

The `agent === "opencode" || agent === "qwen"` condition in the parser meant Qwen got the same minimal parsing as opencode, which only handles flat string fields. Qwen Coder's default output format is stream-json with nested structured objects, so the parser's `JSON.parse` succeeded but none of the field checks matched, returning `{ kind: "noise" }` for every line.

## What was fixed

Separated Qwen into its own parser block that handles:
- `stream_event` → `content_block_delta` / `text_delta` (fine-grained streaming text)
- `stream_event` → `content_block_delta` / `thinking_delta` (thinking metadata)
- `assistant` message with `tool_use` rescue (HTML from Write/create_file tools)
- `assistant` message text content (fallback when no stream deltas seen)
- `result` with usage/duration_ms/total_cost_usd metadata
- Bare `text`/`content`/`message` fields as a last-resort fallback

## Testing Done

- Verified the change compiles with the existing TypeScript configuration
- The parser now handles the same JSON envelope shapes as the Claude and Qoder parsers
- Falls back gracefully to bare field extraction when structured content is absent
- No changes to opencode parsing behavior (separated into its own condition)

## Related

Fixes #58
Closes https://github.com/nexu-io/html-anything/issues/58