### PR TITLE
fix(claude): add deepseek models to Claude Code model picker

### DIFF
--- a/next/src/lib/agents/detect.ts
+++ b/next/src/lib/agents/detect.ts
@@ -60,6 +60,11 @@ export const AGENTS: AgentDef[] = [
       { id: "claude-opus-4-7", label: "claude-opus-4-7" },
       { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
       { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
+      // DeepSeek models (via `cc switch` or direct config) — kept in the
+      // Claude Code picker so users who route Claude through a custom model
+      // endpoint can switch models without leaving html-anything's UI.
+      { id: "deepseek-v4-pro", label: "deepseek-v4-pro" },
+      { id: "deepseek-v4-flash", label: "deepseek-v4-flash" },
     ],
   },
   {


### PR DESCRIPTION
Users who route Claude Code through a custom model endpoint (e.g. via `cc switch`) need to select `deepseek-v4-pro` or `deepseek-v4-flash` from the model picker. Without these entries, the only way to switch models is to leave html-anything, change the CLI config, and reload.

The DeepSeek TUI adapter already lists both models, but Claude Code's picker was missing them — meaning anyone who uses Claude CLI routed to DeepSeek had no way to switch models from the UI.

Closes #65
