### PR TITLE
fix: parse OpenCode nested part.text in JSON output

### DIFF
--- a/next/src/lib/agents/__tests__/argv.test.ts
+++ b/next/src/lib/agents/__tests__/argv.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { parseLine, makeParser } from "../argv";
+
+function deltas(result: ReturnType<typeof parseLine>) {
+  return result.filter((r) => r.kind === "delta").map((r) => r.text);
+}
+
+describe("parseLine (opencode)", () => {
+  it("extracts text from singular part.text envelope", () => {
+    const line = JSON.stringify({
+      type: "text",
+      part: { type: "text", text: "hello world" },
+    });
+    expect(deltas(parseLine("opencode", line))).toEqual(["hello world"]);
+  });
+
+  it("extracts text from parts[].text array envelope", () => {
+    const line = JSON.stringify({
+      type: "text",
+      parts: [
+        { type: "text", text: "hello " },
+        { type: "text", text: "world" },
+      ],
+    });
+    expect(deltas(parseLine("opencode", line))).toEqual(["hello ", "world"]);
+  });
+
+  it("extracts text from top-level text field", () => {
+    const line = JSON.stringify({ text: "top-level content" });
+    expect(deltas(parseLine("opencode", line))).toContain("top-level content");
+  });
+
+  it("extracts text from top-level content field", () => {
+    const line = JSON.stringify({ content: "content field" });
+    expect(deltas(parseLine("opencode", line))).toContain("content field");
+  });
+
+  it("extracts text from top-level message field", () => {
+    const line = JSON.stringify({ message: "message field" });
+    expect(deltas(parseLine("opencode", line))).toContain("message field");
+  });
+
+  it("produces no non-empty delta when all text fields are empty", () => {
+    const line = JSON.stringify({
+      type: "text",
+      text: "",
+      content: "",
+      message: "",
+      part: { type: "text", text: "" },
+    });
+    expect(deltas(parseLine("opencode", line)).filter(Boolean)).toEqual([]);
+  });
+
+  it("handles empty top-level fields with content in part.text (regression #67)", () => {
+    const line = JSON.stringify({
+      type: "text",
+      text: "",
+      content: "",
+      message: "",
+      part: {
+        type: "text",
+        text: "# 春之声\n\n三月的风是软的。",
+      },
+    });
+    expect(deltas(parseLine("opencode", line))).toContain(
+      "# 春之声\n\n三月的风是软的。",
+    );
+  });
+});
+
+describe("parseLine (qwen)", () => {
+  it("extracts text from singular part.text envelope", () => {
+    const line = JSON.stringify({
+      type: "text",
+      part: { type: "text", text: "qwen output" },
+    });
+    expect(deltas(parseLine("qwen", line))).toEqual(["qwen output"]);
+  });
+
+  it("extracts text from parts[].text array envelope", () => {
+    const line = JSON.stringify({
+      parts: [{ text: "a" }, { text: "b" }],
+    });
+    expect(deltas(parseLine("qwen", line))).toEqual(["a", "b"]);
+  });
+});
+
+describe("makeParser (opencode) multi-line streaming", () => {
+  it("accumulates deltas across multiple lines", () => {
+    const parse = makeParser("opencode");
+    parse(
+      JSON.stringify({ type: "step_start", part: { type: "step-start" } }),
+    );
+    const r2 = parse(
+      JSON.stringify({ type: "text", part: { type: "text", text: "hello" } }),
+    );
+    const r3 = parse(
+      JSON.stringify({
+        type: "text",
+        part: { type: "text", text: " world" },
+      }),
+    );
+    expect(deltas(r2)).toEqual(["hello"]);
+    expect(deltas(r3)).toEqual([" world"]);
+  });
+});

--- a/next/src/lib/agents/argv.ts
+++ b/next/src/lib/agents/argv.ts
@@ -366,6 +366,14 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
     if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
     if (typeof obj.content === "string") out.push({ kind: "delta", text: obj.content });
     if (typeof obj.message === "string") out.push({ kind: "delta", text: obj.message });
+    if (Array.isArray(obj.parts)) {
+      for (const part of obj.parts) {
+        if (typeof part?.text === "string") out.push({ kind: "delta", text: part.text });
+      }
+    }
+    if (obj.type === "text" && typeof obj.part?.text === "string") {
+      out.push({ kind: "delta", text: obj.part.text });
+    }
   }
 
   if (agent === "qoder") {


### PR DESCRIPTION
## Problem

OpenCode's `--format json` output wraps content in nested fields, but the parser only checked top-level `text`/`content`/`message` fields (which are empty strings). This causes both **draft** and **convert** features to produce no output when using OpenCode as the agent.

Closes #67

## OpenCode actual output format

OpenCode emits JSON lines like:

```json
{"type":"text","part":{"type":"text","text":"actual content here"}}
```

The real content lives in:
- `obj.part.text` (single object, when `obj.type === "text"`)
- `obj.parts[].text` (array form, for forward-compatibility)

Top-level `text`/`content`/`message` are empty strings.

## Fix

Extended the OpenCode/Qwen parser in `argv.ts` to also extract content from:
1. `obj.parts[].text` — array form
2. `obj.part.text` when `obj.type === "text"` — the actual current output format

## Testing

```bash
# Before fix: no delta events
curl -N http://localhost:10033/api/draft \
  -H "Content-Type: application/json" \
  -d '{"agent":"opencode","instruction":"写一句关于春天的短句"}' 2>/dev/null
# → event: start → event: done (no delta)

# After fix: delta events with content
# → event: start → event: delta {"type":"delta","text":"春风拂过枝头，万物在泥土里翻了个身。"} → event: done
```

## Relationship to PR #78

PR #78 addressed this issue by adding `parts[].text` parsing, but it doesn't cover the actual `part.text` (singular) field that OpenCode currently emits. This PR covers both cases.