### PR TITLE
fix(agents): quote bin path on Windows to support spaces in PATH

### DIFF
--- a/next/src/lib/agents/detect.ts
+++ b/next/src/lib/agents/detect.ts
@@ -360,9 +360,10 @@ export async function resolveOpenclawAgentId(bin: string): Promise<string> {
   try {
     const { spawn } = await import("node:child_process");
     const out = await new Promise<string>((res, rej) => {
-      const child = spawn(bin, ["agents", "list"], {
+      const useShell = process.platform === "win32";
+      const child = spawn(useShell ? `"${bin}"` : bin, ["agents", "list"], {
         stdio: ["ignore", "pipe", "pipe"],
-        shell: process.platform === "win32",
+        shell: useShell,
       });
       let buf = "";
       child.stdout.setEncoding("utf8");

--- a/next/src/lib/agents/invoke.ts
+++ b/next/src/lib/agents/invoke.ts
@@ -158,18 +158,20 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
       if (promptViaMessageFlag) argv = [...argv, "--message", opts.prompt];
 
       try {
-        child = spawn(bin!, argv, {
+        // On Windows, `spawn` cannot launch a `.cmd` / `.bat` shim (which is
+        // what npm installs for most CLI agents) without going through the
+        // shell. Without this, every agent invocation fails with
+        // EINVAL / "spawn 无效的参数". macOS/Linux use direct exec.
+        // Safety: prompt content is delivered via stdin or `--message
+        // <text>` (argv-message), not interpolated into a shell command,
+        // so this does not introduce a shell-injection vector.
+        const useShell = process.platform === "win32";
+        child = spawn(useShell ? `"${bin}"` : bin!, argv, {
           cwd: opts.cwd ?? process.cwd(),
           env,
           stdio: ["pipe", "pipe", "pipe"],
-          // On Windows, `spawn` cannot launch a `.cmd` / `.bat` shim (which is
-          // what npm installs for most CLI agents) without going through the
-          // shell. Without this, every agent invocation fails with
-          // EINVAL / "spawn 无效的参数". macOS/Linux use direct exec.
-          // Safety: prompt content is delivered via stdin or `--message
-          // <text>` (argv-message), not interpolated into a shell command,
-          // so this does not introduce a shell-injection vector.
-          shell: process.platform === "win32",
+          shell: useShell,
+          windowsVerbatimArguments: false,
         });
       } catch (err) {
         safeEnqueue({


### PR DESCRIPTION
## Summary

- On Windows, `spawn` with `shell: true` concatenates the binary path and argv into a single command string. When the resolved CLI binary lives under a directory with spaces (e.g. `C:\Program Files\nodejs\node_global\claude.CMD`), `cmd.exe` splits on the space and fails with `'C:\Program' is not recognized as an internal or external command`.
- Fix: wrap `bin` in double quotes when `useShell` is true, so `cmd.exe` correctly parses paths containing spaces.

## Root cause

`next/src/lib/agents/invoke.ts` line 161 — `spawn(bin!, argv, { shell: true })` on Windows passes the unquoted `bin` to `cmd.exe /c`, which breaks on spaces.

## Test plan

- [x] On Windows 11 with Claude CLI installed at `C:\Program Files\nodejs\node_global\claude.CMD`, press Ctrl+Enter in the editor → agent spawns successfully and streams HTML
- [x] Verified SSE output shows `event: start` followed by `event: delta` (real content) instead of `event: stderr` + `event: done` (exit code 1)
- [ ] Verify macOS/Linux behavior is unchanged (shell is not used on those platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)