### PR TITLE
Add business decision skills

### DIFF
--- a/next/src/lib/templates/skills/competitive-teardown/SKILL.md
+++ b/next/src/lib/templates/skills/competitive-teardown/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: competitive-teardown
+zh_name: "竞品拆解"
+en_name: "Competitive Teardown"
+emoji: "🧩"
+description: "定位图 + 功能矩阵 + 价格对比 + 机会窗口, 把竞品资料转成产品决策报告"
+category: doc
+scenario: product
+aspect_hint: "战略长页面"
+featured: 8
+tags: ["competitive", "teardown", "strategy", "product", "竞品", "拆解"]
+example_id: sample-competitive-teardown
+example_name: "竞品拆解 · AI Meeting Assistants"
+example_format: markdown
+example_tagline: "比较矩阵 + 定位象限 + 我们的应对"
+example_desc: "把三家竞品的定位、价格、功能、评价转成产品团队可行动的拆解报告。"
+---
+
+【模板: 竞品拆解 / Competitive Teardown】
+【意图】这不是文章、不是 PRD、不是 pitch deck。目标是把多个竞品的杂乱资料转成一份可决策的产品战略报告, 帮团队回答: "我们和它们到底差在哪里, 下一步该怎么打?"
+
+【适合输入】
+- 竞品官网 / 定价页 / changelog / 用户评论 / 销售反馈 / 内部调研笔记
+- 2-6 个竞品最合适; 如果用户只给一个竞品, 输出单竞品 deep dive
+- 可以包含表格、bullet、链接摘录、访谈记录、截图说明
+
+【必须输出的结构】
+1. Header: 市场 / 产品类别 / 报告日期 / 结论一句话。
+2. Executive takeaway: 3 条最重要判断, 每条必须包含 "so what"。
+3. Positioning map: 用 2×2 象限或坐标图表现竞品定位。坐标轴必须来自用户内容, 不要套模板词。
+4. Competitor cards: 每个竞品一张卡, 包含 target user、core promise、pricing signal、primary strength、visible weakness。
+5. Feature matrix: 行是关键能力, 列是竞品 + "Us / Opportunity"; 用 ✓ / △ / — 表达覆盖度, 并用短注释说明。
+6. Pricing / packaging read: 价格层级、免费试用、限制项、企业销售动作。
+7. UX / messaging notes: 从用户材料中抽取 4-6 条可观察细节, 不要泛泛而谈。
+8. Opportunity windows: 3 个机会窗口, 每个包含 why now、target segment、first move、risk。
+9. Recommended moves: 近期 30 天 / 90 天 / 180 天行动建议。
+
+【设计要求】
+- 战略咨询 + 产品战情室风格: 信息密度高、扫描快、图表清楚。
+- 使用 restrained palette: ink / paper / muted blue / signal amber 或类似专业色。
+- Feature matrix 必须横向可读; 小屏可变成 stacked cards。
+- 不要做成营销落地页, 不要做成普通文章。
+
+【可选风格模板 — 参考 assets/】
+根据用户内容选择最贴合的一种, 不要三种混用:
+- `assets/war-room-grid.html`: 默认风格。浅色战情室 / 咨询报告, 适合产品团队、PM、普通商业读者。
+- `assets/radar-map.html`: 深色雷达图 / market intelligence console, 适合安全、AI、开发者工具、平台型竞品。
+- `assets/analyst-dossier.html`: 纸质分析档案 / investment research dossier, 适合投研、行业分析、正式战略备忘。
+
+如果用户没有指定风格, 优先使用 `war-room-grid`; 如果输入强调市场格局、技术雷达、攻防态势, 使用 `radar-map`; 如果输入像研究笔记、投资备忘或行业报告, 使用 `analyst-dossier`。
+
+【内容真实性】
+- 只使用用户提供的竞品、价格、功能、评论。缺失信息用 "not found in source" 或 "unknown" 标注。
+- 不要发明市场份额、ARR、客户名、定价数字。
+- 如果用户资料明显不足, 仍然输出报告, 但在 "Evidence gaps" 中列出缺口。

--- a/next/src/lib/templates/skills/competitive-teardown/assets/analyst-dossier.html
+++ b/next/src/lib/templates/skills/competitive-teardown/assets/analyst-dossier.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Competitive Teardown · Analyst Dossier</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@500;700&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--paper:#f4efe3;--ink:#1d1b16;--muted:#6d6558;--line:#cfc4b0;--red:#9b2f23;--blue:#284b7a}
+    body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1120px;margin:auto;padding:42px 28px 58px}
+    .serif{font-family:"IBM Plex Serif",Georgia,serif}.rule{border-top:3px double var(--ink);border-bottom:1px solid var(--ink)}.box{border:1px solid var(--line);background:#fbf7ee}
+    .stamp{border:2px solid var(--red);color:var(--red);transform:rotate(-2deg);display:inline-block;padding:5px 10px;font-weight:800;text-transform:uppercase;letter-spacing:.12em;font-size:11px}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;vertical-align:top;font-size:13px}th{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="rule py-5 flex flex-wrap items-end justify-between gap-4">
+      <div><div class="stamp">Competitive dossier</div><h1 class="serif mt-4 text-6xl leading-[.96] font-bold">AI meeting assistants: the open flank.</h1></div>
+      <div class="text-right text-sm text-[var(--muted)]"><b>Prepared for:</b> Product Strategy<br><b>Question:</b> Where should LoopNote compete?</div>
+    </header>
+    <section class="grid lg:grid-cols-[.7fr_1.3fr] gap-5 mt-6">
+      <aside class="box p-5">
+        <h2 class="serif text-2xl font-bold">Thesis</h2>
+        <p class="mt-3 leading-7 text-[var(--muted)]">The visible market is crowded around note capture. The under-defended space is durable product insight across repeated customer conversations.</p>
+        <div class="mt-6 text-sm leading-7"><b>Do:</b> product discovery memory<br><b>Avoid:</b> generic transcription parity<br><b>Proof point:</b> source notes show no competitor owning cross-interview insight cards.</div>
+      </aside>
+      <section class="box overflow-hidden">
+        <table><thead><tr><th>Competitor</th><th>Promise</th><th>Strength</th><th>Weakness</th></tr></thead><tbody>
+          <tr><td><b>Granola</b></td><td>AI notes for people in meetings.</td><td>Personal, invisible, low-friction.</td><td>Team analytics not obvious.</td></tr>
+          <tr><td><b>Fireflies</b></td><td>Automate meeting notes.</td><td>Integrations and searchable library.</td><td>Heavy workflow; visible bot.</td></tr>
+          <tr><td><b>Fathom</b></td><td>Never take notes on Zoom.</td><td>Free individual capture, CRM utility.</td><td>Less focused on product insight synthesis.</td></tr>
+        </tbody></table>
+      </section>
+    </section>
+    <section class="grid md:grid-cols-3 gap-5 mt-5">
+      <div class="box p-5"><h3 class="serif text-xl font-bold">30-day move</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Reframe objects around interviews, pain, quotes, objections, and feature requests.</p></div>
+      <div class="box p-5"><h3 class="serif text-xl font-bold">90-day move</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Ship cross-call synthesis and export to PRD / roadmap workflows.</p></div>
+      <div class="box p-5"><h3 class="serif text-xl font-bold">Evidence gaps</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Need 8-12 product-team interviews and willingness-to-pay signal for research memory.</p></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/competitive-teardown/assets/radar-map.html
+++ b/next/src/lib/templates/skills/competitive-teardown/assets/radar-map.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Competitive Teardown · Radar Map</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#08111f;--panel:#0d1b2d;--line:#223651;--ink:#e7eefc;--muted:#91a4c3;--cyan:#38d5ff;--lime:#9ef36a;--pink:#ff6aa2}
+    body{margin:0;background:radial-gradient(circle at 70% 10%,#173761 0,#08111f 46%,#050914 100%);color:var(--ink);font-family:Inter,system-ui,sans-serif}
+    .page{max-width:1200px;margin:auto;padding:38px 26px 56px}.panel{border:1px solid var(--line);background:rgba(13,27,45,.76);border-radius:8px;box-shadow:0 20px 60px rgba(0,0,0,.25)}
+    .chip{border:1px solid var(--line);border-radius:999px;padding:6px 10px;color:var(--muted);font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.1em}
+    .radar{background:repeating-radial-gradient(circle at center,transparent 0 44px,rgba(56,213,255,.25) 45px 46px),linear-gradient(90deg,transparent 49.8%,rgba(56,213,255,.28) 50%,transparent 50.2%),linear-gradient(0deg,transparent 49.8%,rgba(56,213,255,.28) 50%,transparent 50.2%)}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:14px;text-align:left;font-size:13px;vertical-align:top}th{color:var(--muted);text-transform:uppercase;letter-spacing:.09em;font-size:11px}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="panel p-7">
+      <div class="flex flex-wrap gap-2 mb-6"><span class="chip">Radar map</span><span class="chip">AI meeting assistants</span><span class="chip">Product strategy</span></div>
+      <div class="grid lg:grid-cols-[.9fr_1.1fr] gap-8">
+        <div>
+          <p class="text-[var(--cyan)] text-sm font-bold mb-3">Strategic read</p>
+          <h1 class="text-6xl font-extrabold leading-[.94]">Own the insight layer.</h1>
+          <p class="mt-5 text-lg leading-8 text-[var(--muted)]">Granola wins personal capture. Fireflies and Fathom win workflow breadth. LoopNote should map raw conversations into product decisions.</p>
+        </div>
+        <div class="panel radar relative h-[420px] overflow-hidden">
+          <div class="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--cyan)] shadow-[0_0_28px_var(--cyan)]"></div>
+          <div class="absolute left-[18%] top-[62%] rounded-full bg-[#10294f] px-4 py-2 text-sm font-extrabold text-[var(--cyan)]">Granola</div>
+          <div class="absolute right-[14%] top-[45%] rounded-full bg-[#203117] px-4 py-2 text-sm font-extrabold text-[var(--lime)]">Fireflies</div>
+          <div class="absolute right-[24%] bottom-[18%] rounded-full bg-[#3b1730] px-4 py-2 text-sm font-extrabold text-[var(--pink)]">Fathom</div>
+          <div class="absolute left-[42%] top-[26%] rounded-full bg-[var(--ink)] px-5 py-3 text-sm font-extrabold text-[#08111f]">LoopNote wedge</div>
+          <div class="absolute left-5 top-5 text-xs uppercase tracking-widest text-[var(--muted)]">Synthesis intensity</div>
+          <div class="absolute right-5 bottom-5 text-xs uppercase tracking-widest text-[var(--muted)]">Workflow gravity</div>
+        </div>
+      </div>
+    </section>
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="panel p-5"><div class="text-[var(--cyan)] text-xs font-bold uppercase">Granola</div><h2 class="mt-3 text-2xl font-extrabold">Invisible personal notes</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Best signal: meeting-heavy individuals who want AI without bot ceremony.</p></article>
+      <article class="panel p-5"><div class="text-[var(--lime)] text-xs font-bold uppercase">Fireflies</div><h2 class="mt-3 text-2xl font-extrabold">Searchable conversation ops</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Best signal: integrations, transcript memory, sales and CS workflow.</p></article>
+      <article class="panel p-5"><div class="text-[var(--pink)] text-xs font-bold uppercase">Fathom</div><h2 class="mt-3 text-2xl font-extrabold">Free sales capture</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Best signal: fast highlight capture and very clear CRM-adjacent value.</p></article>
+    </section>
+    <section class="panel mt-5 overflow-hidden">
+      <table><thead><tr><th>Vector</th><th>Market evidence</th><th>Our move</th><th>Risk</th></tr></thead><tbody>
+        <tr><td><b>Capture</b></td><td>Competitors already anchor here.</td><td>Meet parity only where product research needs it.</td><td>Feature treadmill.</td></tr>
+        <tr><td><b>Synthesis</b></td><td>Source notes show no clear owner.</td><td>Turn calls into pain clusters, quotes, and roadmap inputs.</td><td>Requires opinionated taxonomy.</td></tr>
+        <tr><td><b>Team workflow</b></td><td>Fireflies is broad, Fathom is sales-specific.</td><td>Package for product discovery teams.</td><td>Narrower TAM story.</td></tr>
+      </tbody></table>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/competitive-teardown/assets/war-room-grid.html
+++ b/next/src/lib/templates/skills/competitive-teardown/assets/war-room-grid.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Competitive Teardown · AI Meeting Assistants</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--ink:#162033;--muted:#667085;--paper:#f7f4ec;--line:#ded7ca;--blue:#1d4ed8;--amber:#c47b25;--green:#28715f}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1180px;margin:0 auto;padding:42px 28px 56px}.hair{border:1px solid var(--line);background:rgba(255,255,255,.54)}
+    .pill{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .grid-bg{background-image:linear-gradient(var(--line) 1px,transparent 1px),linear-gradient(90deg,var(--line) 1px,transparent 1px);background-size:32px 32px}
+    .matrix th,.matrix td{border-bottom:1px solid var(--line);padding:14px;text-align:left;vertical-align:top}.matrix th{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}.matrix td{font-size:13px}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hair grid-bg rounded-[6px] p-7">
+      <div class="flex flex-wrap items-center gap-2 mb-8">
+        <span class="pill">Competitive teardown</span><span class="pill">AI meeting assistants</span><span class="pill">2026-05-28</span>
+      </div>
+      <div class="grid md:grid-cols-[1.25fr_.75fr] gap-8 items-end">
+        <div>
+          <p class="text-sm font-bold text-[var(--blue)] mb-3">LoopNote should avoid generic transcription and own product-discovery memory.</p>
+          <h1 class="text-5xl md:text-7xl font-extrabold leading-[.92] tracking-tight">Competing on synthesis, not capture.</h1>
+        </div>
+        <div class="hair rounded-[6px] p-5 bg-[#fffaf0]">
+          <div class="text-xs font-bold text-[var(--muted)] uppercase tracking-wider mb-3">Executive takeaway</div>
+          <ol class="space-y-3 text-sm leading-6">
+            <li><b>1.</b> Granola owns low-friction personal notes; Fireflies and Fathom own capture workflows.</li>
+            <li><b>2.</b> LoopNote's wedge is cross-interview product insight synthesis.</li>
+            <li><b>3.</b> The next 90 days should prove a product-team workflow, not chase every meeting use case.</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Granola</div><h2 class="text-2xl font-extrabold">Personal AI notepad</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Best at feeling invisible and personal for people in back-to-back meetings.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Fireflies</div><h2 class="text-2xl font-extrabold">Conversation library</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Broad integrations and searchable transcripts for sales, recruiting, and CS teams.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Fathom</div><h2 class="text-2xl font-extrabold">Free sales notetaker</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Clear highlight capture and CRM utility; strongest around individual call follow-up.</p></article>
+    </section>
+
+    <section class="grid lg:grid-cols-[.9fr_1.1fr] gap-5 mt-5">
+      <div class="hair rounded-[6px] p-6 bg-[#fbfaf6]">
+        <div class="flex justify-between text-xs font-bold text-[var(--muted)] uppercase tracking-wider mb-4"><span>Positioning map</span><span>derived from source notes</span></div>
+        <div class="relative h-[360px] border border-[var(--line)] bg-white">
+          <div class="absolute left-1/2 top-0 bottom-0 border-l border-dashed border-[var(--line)]"></div>
+          <div class="absolute top-1/2 left-0 right-0 border-t border-dashed border-[var(--line)]"></div>
+          <div class="absolute left-3 top-3 text-xs text-[var(--muted)]">High synthesis</div>
+          <div class="absolute right-3 bottom-3 text-xs text-[var(--muted)]">Team workflow</div>
+          <div class="absolute left-[18%] bottom-[26%] rounded-full bg-[#e8eefc] px-3 py-2 text-sm font-bold text-[var(--blue)]">Granola</div>
+          <div class="absolute right-[13%] top-[42%] rounded-full bg-[#fff1dc] px-3 py-2 text-sm font-bold text-[var(--amber)]">Fireflies</div>
+          <div class="absolute right-[22%] bottom-[24%] rounded-full bg-[#ecfdf5] px-3 py-2 text-sm font-bold text-[var(--green)]">Fathom</div>
+          <div class="absolute left-[42%] top-[18%] rounded-full bg-[var(--ink)] px-4 py-2 text-sm font-bold text-white shadow-lg">LoopNote wedge</div>
+        </div>
+      </div>
+      <div class="hair rounded-[6px] bg-white/70 overflow-hidden">
+        <table class="matrix w-full">
+          <thead><tr><th>Capability</th><th>Granola</th><th>Fireflies</th><th>Fathom</th><th>LoopNote opportunity</th></tr></thead>
+          <tbody>
+            <tr><td><b>Invisible note capture</b></td><td>✓ strong</td><td>△ bot-like</td><td>△ call tool</td><td>Do not compete head-on</td></tr>
+            <tr><td><b>Transcript library</b></td><td>unknown</td><td>✓ strong</td><td>△ useful</td><td>Only store what supports research synthesis</td></tr>
+            <tr><td><b>CRM / sales workflow</b></td><td>not found</td><td>✓ broad</td><td>✓ clear</td><td>Avoid sales-first packaging</td></tr>
+            <tr><td><b>Cross-interview insight cards</b></td><td>not found</td><td>△ searchable</td><td>not found</td><td><b>Primary wedge</b></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">30 days</span><h3 class="mt-4 text-xl font-extrabold">Package for product discovery</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Rename core objects around interviews, pain, quotes, requests, and insight clusters.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">90 days</span><h3 class="mt-4 text-xl font-extrabold">Build research memory</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Ship cross-call synthesis, tagging, and export to PRD / roadmap workflows.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">180 days</span><h3 class="mt-4 text-xl font-extrabold">Integrate selectively</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add calendar bot only when it strengthens product research capture, not as generic parity.</p></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/competitive-teardown/example.html
+++ b/next/src/lib/templates/skills/competitive-teardown/example.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Competitive Teardown · AI Meeting Assistants</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--ink:#162033;--muted:#667085;--paper:#f7f4ec;--line:#ded7ca;--blue:#1d4ed8;--amber:#c47b25;--green:#28715f}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1180px;margin:0 auto;padding:42px 28px 56px}.hair{border:1px solid var(--line);background:rgba(255,255,255,.54)}
+    .pill{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .grid-bg{background-image:linear-gradient(var(--line) 1px,transparent 1px),linear-gradient(90deg,var(--line) 1px,transparent 1px);background-size:32px 32px}
+    .matrix th,.matrix td{border-bottom:1px solid var(--line);padding:14px;text-align:left;vertical-align:top}.matrix th{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}.matrix td{font-size:13px}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hair grid-bg rounded-[6px] p-7">
+      <div class="flex flex-wrap items-center gap-2 mb-8">
+        <span class="pill">Competitive teardown</span><span class="pill">AI meeting assistants</span><span class="pill">2026-05-28</span>
+      </div>
+      <div class="grid md:grid-cols-[1.25fr_.75fr] gap-8 items-end">
+        <div>
+          <p class="text-sm font-bold text-[var(--blue)] mb-3">LoopNote should avoid generic transcription and own product-discovery memory.</p>
+          <h1 class="text-5xl md:text-7xl font-extrabold leading-[.92] tracking-tight">Competing on synthesis, not capture.</h1>
+        </div>
+        <div class="hair rounded-[6px] p-5 bg-[#fffaf0]">
+          <div class="text-xs font-bold text-[var(--muted)] uppercase tracking-wider mb-3">Executive takeaway</div>
+          <ol class="space-y-3 text-sm leading-6">
+            <li><b>1.</b> Granola owns low-friction personal notes; Fireflies and Fathom own capture workflows.</li>
+            <li><b>2.</b> LoopNote's wedge is cross-interview product insight synthesis.</li>
+            <li><b>3.</b> The next 90 days should prove a product-team workflow, not chase every meeting use case.</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Granola</div><h2 class="text-2xl font-extrabold">Personal AI notepad</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Best at feeling invisible and personal for people in back-to-back meetings.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Fireflies</div><h2 class="text-2xl font-extrabold">Conversation library</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Broad integrations and searchable transcripts for sales, recruiting, and CS teams.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><div class="text-xs text-[var(--muted)] mb-2">Fathom</div><h2 class="text-2xl font-extrabold">Free sales notetaker</h2><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Clear highlight capture and CRM utility; strongest around individual call follow-up.</p></article>
+    </section>
+
+    <section class="grid lg:grid-cols-[.9fr_1.1fr] gap-5 mt-5">
+      <div class="hair rounded-[6px] p-6 bg-[#fbfaf6]">
+        <div class="flex justify-between text-xs font-bold text-[var(--muted)] uppercase tracking-wider mb-4"><span>Positioning map</span><span>derived from source notes</span></div>
+        <div class="relative h-[360px] border border-[var(--line)] bg-white">
+          <div class="absolute left-1/2 top-0 bottom-0 border-l border-dashed border-[var(--line)]"></div>
+          <div class="absolute top-1/2 left-0 right-0 border-t border-dashed border-[var(--line)]"></div>
+          <div class="absolute left-3 top-3 text-xs text-[var(--muted)]">High synthesis</div>
+          <div class="absolute right-3 bottom-3 text-xs text-[var(--muted)]">Team workflow</div>
+          <div class="absolute left-[18%] bottom-[26%] rounded-full bg-[#e8eefc] px-3 py-2 text-sm font-bold text-[var(--blue)]">Granola</div>
+          <div class="absolute right-[13%] top-[42%] rounded-full bg-[#fff1dc] px-3 py-2 text-sm font-bold text-[var(--amber)]">Fireflies</div>
+          <div class="absolute right-[22%] bottom-[24%] rounded-full bg-[#ecfdf5] px-3 py-2 text-sm font-bold text-[var(--green)]">Fathom</div>
+          <div class="absolute left-[42%] top-[18%] rounded-full bg-[var(--ink)] px-4 py-2 text-sm font-bold text-white shadow-lg">LoopNote wedge</div>
+        </div>
+      </div>
+      <div class="hair rounded-[6px] bg-white/70 overflow-hidden">
+        <table class="matrix w-full">
+          <thead><tr><th>Capability</th><th>Granola</th><th>Fireflies</th><th>Fathom</th><th>LoopNote opportunity</th></tr></thead>
+          <tbody>
+            <tr><td><b>Invisible note capture</b></td><td>✓ strong</td><td>△ bot-like</td><td>△ call tool</td><td>Do not compete head-on</td></tr>
+            <tr><td><b>Transcript library</b></td><td>unknown</td><td>✓ strong</td><td>△ useful</td><td>Only store what supports research synthesis</td></tr>
+            <tr><td><b>CRM / sales workflow</b></td><td>not found</td><td>✓ broad</td><td>✓ clear</td><td>Avoid sales-first packaging</td></tr>
+            <tr><td><b>Cross-interview insight cards</b></td><td>not found</td><td>△ searchable</td><td>not found</td><td><b>Primary wedge</b></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">30 days</span><h3 class="mt-4 text-xl font-extrabold">Package for product discovery</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Rename core objects around interviews, pain, quotes, requests, and insight clusters.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">90 days</span><h3 class="mt-4 text-xl font-extrabold">Build research memory</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Ship cross-call synthesis, tagging, and export to PRD / roadmap workflows.</p></article>
+      <article class="hair rounded-[6px] p-5 bg-white/70"><span class="pill">180 days</span><h3 class="mt-4 text-xl font-extrabold">Integrate selectively</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add calendar bot only when it strengthens product research capture, not as generic parity.</p></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/competitive-teardown/example.md
+++ b/next/src/lib/templates/skills/competitive-teardown/example.md
@@ -1,0 +1,43 @@
+# AI Meeting Assistant Competitive Teardown
+
+Date: 2026-05-28
+Category: AI meeting assistants for product and customer teams
+Our product: LoopNote, a lightweight meeting memory tool for product discovery calls.
+
+## Competitors
+
+### Granola
+- Positioning: AI notepad for people who take a lot of meetings.
+- User: founders, managers, operators.
+- Pricing signal: individual subscription, public site emphasizes simplicity.
+- Strength: feels personal and low-friction; users like that it does not behave like a visible bot.
+- Weakness: less obvious team analytics or CRM workflow.
+- Messaging: "AI notes for people in back-to-back meetings."
+
+### Fireflies
+- Positioning: meeting transcription, summary, and searchable conversation intelligence.
+- User: sales, recruiting, customer success.
+- Pricing signal: free plan plus paid tiers; team/workspace orientation.
+- Strength: broad integrations, searchable transcript library, sales workflow.
+- Weakness: can feel heavy; visible bot may make some calls less natural.
+- Messaging: "Automate meeting notes."
+
+### Fathom
+- Positioning: free AI meeting notetaker with highlights and CRM sync.
+- User: sales reps, customer-facing teams.
+- Pricing signal: free individual product, paid team edition.
+- Strength: fast highlight capture, very clear sales utility.
+- Weakness: primarily meeting capture; less focused on long-term product insight synthesis.
+- Messaging: "Never take notes on a Zoom call again."
+
+## LoopNote current state
+- Works best for product discovery interviews and research calls.
+- Chrome extension captures user-marked moments during calls.
+- Generates insight cards after the meeting: pain, quote, feature request, objection.
+- Weakness: no native calendar bot yet, limited integrations, pricing not finalized.
+- Strength: stronger synthesis across multiple interviews than single-call summary tools.
+
+## Product goals
+- Find a wedge that avoids competing head-on with generic transcription tools.
+- Identify a packaging angle for product teams.
+- Decide what to build in the next 90 days.

--- a/next/src/lib/templates/skills/exec-briefing-memo/SKILL.md
+++ b/next/src/lib/templates/skills/exec-briefing-memo/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: exec-briefing-memo
+zh_name: "高管决策简报"
+en_name: "Executive Briefing Memo"
+emoji: "⚖️"
+description: "Decision needed + recommendation + evidence + tradeoffs, 把复杂材料压成可拍板的一页"
+category: doc
+scenario: operations
+aspect_hint: "一页决策 memo"
+featured: 8
+tags: ["executive", "briefing", "memo", "decision", "strategy", "简报", "决策"]
+example_id: sample-exec-briefing-memo
+example_name: "高管简报 · 是否进入 Enterprise Plan"
+example_format: markdown
+example_tagline: "推荐动作 + 权衡 + 风险 + 下一步"
+example_desc: "把产品、销售、财务反馈压缩成一页高管可拍板 memo。"
+---
+
+【模板: 高管决策简报 / Executive Briefing Memo】
+【意图】这不是会议纪要、不是周报、不是 PRD。它的唯一目标是帮助决策者在 3 分钟内理解问题并拍板。
+
+【适合输入】
+- 长会议记录、调研材料、战略讨论、销售反馈、产品数据、投资备忘
+- 用户可能给很多碎片信息; 你要提炼成一个明确 decision frame
+
+【必须输出的结构】
+1. Memo header: 主题、owner、audience、date、decision deadline。
+2. Decision needed: 用一句话写清楚需要拍板的问题。
+3. Recommendation: 明确建议, 不要写 "可以考虑"。必须包含 confidence level。
+4. Why now: 为什么现在需要决定, 不决定的代价是什么。
+5. Key facts: 5-7 个事实证据, 每条标注来源类型 (sales / product / finance / customer / ops)。
+6. Tradeoff table: Option A / Option B / Option C, 对比 upside、cost、risk、reversibility。
+7. Risks & mitigations: 3-5 个风险, 每个给缓解动作。
+8. Decision path: approve / reject / ask for more evidence 三种路径各自下一步。
+9. Next actions: owner、due date、expected artifact。
+
+【设计要求】
+- 像顶级咨询公司的 one-page decision memo: 克制、清楚、密度高。
+- 首屏必须直接呈现 decision + recommendation, 不要先铺陈背景。
+- 使用强层级: 大号结论、紧凑证据卡、对比表、状态 pill。
+- 不要做成长文章; 不要做成 deck; 不要写空泛商业黑话。
+
+【可选风格模板 — 参考 assets/】
+根据决策场景选择一种, 不要三种混用:
+- `assets/board-memo.html`: 默认风格。浅色高管 memo, 适合 CEO/CFO/CRO、运营、产品决策。
+- `assets/decision-command.html`: 深色 command center, 适合紧急决策、风险处置、incident、go/no-go、launch gate。
+- `assets/board-paper.html`: 正式 board paper / 董事会纸质议案, 适合董事会、投资人、合规、预算审批。
+
+如果用户没有指定风格, 优先使用 `board-memo`; 如果材料强调紧急、风险、行动指挥, 使用 `decision-command`; 如果材料面向董事会或正式审批, 使用 `board-paper`。
+
+【内容真实性】
+- 不要捏造数字、客户、预算、日期。
+- 如果缺少关键信息, 在 Evidence gaps 中列出, 但仍给出基于现有证据的 provisional recommendation。

--- a/next/src/lib/templates/skills/exec-briefing-memo/assets/board-memo.html
+++ b/next/src/lib/templates/skills/exec-briefing-memo/assets/board-memo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Executive Briefing Memo · Enterprise Plan</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--ink:#111827;--muted:#667085;--paper:#faf9f5;--line:#e4dfd4;--red:#a84332;--green:#1f7a58;--blue:#254f9c}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1120px;margin:0 auto;padding:40px 26px 54px}.box{border:1px solid var(--line);background:rgba(255,255,255,.72);border-radius:6px}
+    .label{font-size:11px;text-transform:uppercase;letter-spacing:.1em;font-weight:800;color:var(--muted)}.pill{border-radius:999px;padding:6px 10px;font-size:11px;font-weight:800}
+    table{width:100%;border-collapse:collapse} th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;vertical-align:top;font-size:13px} th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="box p-7">
+      <div class="flex flex-wrap justify-between gap-3 mb-8">
+        <div class="flex flex-wrap gap-2"><span class="pill bg-[#eef2ff] text-[var(--blue)]">Executive memo</span><span class="pill bg-white border border-[var(--line)]">Owner: Maya Chen</span><span class="pill bg-white border border-[var(--line)]">Deadline: 2026-06-14</span></div>
+        <div class="label">Audience: CEO / CRO / CFO</div>
+      </div>
+      <div class="grid lg:grid-cols-[1.15fr_.85fr] gap-8">
+        <div>
+          <div class="label mb-2">Decision needed</div>
+          <h1 class="text-5xl md:text-6xl font-extrabold leading-[.95] tracking-tight">Should FlowLedger launch an Enterprise Plan in Q3?</h1>
+        </div>
+        <div class="box p-5 bg-[#f0f8f4]">
+          <div class="label mb-3 text-[var(--green)]">Recommendation</div>
+          <h2 class="text-2xl font-extrabold">Approve a narrow Enterprise Preview.</h2>
+          <p class="mt-3 text-sm leading-6 text-[var(--muted)]">Build SSO, audit logs, annual invoicing, and a security questionnaire motion. Defer custom retention and full enterprise operations.</p>
+          <div class="mt-5 flex gap-2"><span class="pill bg-white text-[var(--green)] border border-[#badbcc]">Confidence: medium-high</span><span class="pill bg-white text-[var(--ink)] border border-[var(--line)]">Reversible</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-4 gap-4 mt-5">
+      <div class="box p-5"><div class="label">Enterprise asks</div><div class="mt-2 text-4xl font-extrabold">18</div><p class="text-sm text-[var(--muted)] mt-2">inbound requests in 45 days</p></div>
+      <div class="box p-5"><div class="label">Large accounts</div><div class="mt-2 text-4xl font-extrabold">7</div><p class="text-sm text-[var(--muted)] mt-2">over 500 employees</p></div>
+      <div class="box p-5"><div class="label">Potential ACV</div><div class="mt-2 text-4xl font-extrabold">$18k-35k</div><p class="text-sm text-[var(--muted)] mt-2">sales estimate, not proven</p></div>
+      <div class="box p-5"><div class="label">Roadmap cost</div><div class="mt-2 text-4xl font-extrabold">4-6w</div><p class="text-sm text-[var(--muted)] mt-2">delay risk to bank reconciliation</p></div>
+    </section>
+
+    <section class="grid lg:grid-cols-[1.1fr_.9fr] gap-5 mt-5">
+      <div class="box overflow-hidden">
+        <div class="p-5 border-b border-[var(--line)]"><div class="label">Tradeoff table</div></div>
+        <table>
+          <thead><tr><th>Option</th><th>Upside</th><th>Cost</th><th>Risk</th><th>Reversibility</th></tr></thead>
+          <tbody>
+            <tr><td><b>No enterprise in 2026</b></td><td>Protects roadmap focus</td><td>Leaves 18 asks unanswered</td><td>Missed market signal</td><td>Medium</td></tr>
+            <tr><td><b>Enterprise Preview</b></td><td>Tests willingness to pay</td><td>5 weeks for SSO + audit logs</td><td>Support load</td><td>High</td></tr>
+            <tr><td><b>Full Enterprise Plan</b></td><td>Stronger enterprise story</td><td>Retention, SCIM, SLA, CSM</td><td>Premature motion</td><td>Low</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="box p-5">
+        <div class="label mb-4">Risks & mitigations</div>
+        <div class="space-y-4 text-sm leading-6">
+          <p><b>Enterprise distraction:</b> cap scope to SSO, audit logs, annual invoicing, and security questionnaire.</p>
+          <p><b>Pricing uncertainty:</b> sell as preview to first 3 annual prospects before expanding scope.</p>
+          <p><b>Support readiness:</b> create one security questionnaire owner and canned response library.</p>
+          <p><b>Roadmap delay:</b> explicitly defer custom retention until ACV evidence exists.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="box p-6 mt-5">
+      <div class="label mb-4">Decision path</div>
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="border-l-4 border-[var(--green)] pl-4"><h3 class="font-extrabold">Approve</h3><p class="text-sm text-[var(--muted)] mt-2">Start Enterprise Preview spec this week; sales identifies 3 design partners.</p></div>
+        <div class="border-l-4 border-[var(--red)] pl-4"><h3 class="font-extrabold">Reject</h3><p class="text-sm text-[var(--muted)] mt-2">Keep self-serve roadmap; log enterprise asks but avoid custom commitments.</p></div>
+        <div class="border-l-4 border-[var(--blue)] pl-4"><h3 class="font-extrabold">Need evidence</h3><p class="text-sm text-[var(--muted)] mt-2">Run 10 prospect calls and validate annual contract willingness by June 14.</p></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/exec-briefing-memo/assets/board-paper.html
+++ b/next/src/lib/templates/skills/exec-briefing-memo/assets/board-paper.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Executive Briefing Memo · Board Paper</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@500;700;800&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--paper:#fbfaf6;--ink:#171717;--muted:#68635b;--line:#d8d0c3;--blue:#183b6b;--green:#216e4e}
+    body{margin:0;background:#ece7dc;color:var(--ink);font-family:Inter,system-ui,sans-serif}.sheet{max-width:980px;margin:34px auto;padding:48px 58px;background:var(--paper);box-shadow:0 24px 70px rgba(58,48,32,.18)}
+    .serif{font-family:"Source Serif 4",Georgia,serif}.kicker{font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.12em;color:var(--muted)}.rule{border-top:1px solid var(--ink);border-bottom:3px double var(--ink)}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top;font-size:13px}th{font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="sheet">
+    <header class="rule py-5">
+      <div class="kicker">Board decision paper · confidential</div>
+      <h1 class="serif mt-3 text-5xl leading-[.98] font-extrabold">Enterprise Plan: approve a narrow preview.</h1>
+      <p class="mt-4 text-sm text-[var(--muted)]">Owner: Maya Chen · Audience: CEO / CRO / CFO · Decision deadline: 2026-06-14</p>
+    </header>
+    <section class="grid md:grid-cols-[.75fr_1.25fr] gap-8 mt-7">
+      <aside>
+        <div class="kicker">Recommendation</div>
+        <p class="serif mt-3 text-2xl leading-8 font-bold text-[var(--green)]">Proceed with Enterprise Preview. Do not fund full enterprise scope yet.</p>
+      </aside>
+      <div class="space-y-4 text-sm leading-7">
+        <p><b>Why now:</b> 18 inbound requests in 45 days indicate real pull, including 7 accounts over 500 employees.</p>
+        <p><b>Constraint:</b> Current roadmap cost is meaningful; bank reconciliation may slip by 4-6 weeks.</p>
+        <p><b>Decision frame:</b> Treat enterprise as a pricing and packaging test, not a company-wide motion.</p>
+      </div>
+    </section>
+    <section class="mt-8">
+      <div class="kicker mb-3">Options analysis</div>
+      <table><thead><tr><th>Option</th><th>Rationale</th><th>Board question</th></tr></thead><tbody>
+        <tr><td><b>Enterprise Preview</b></td><td>SSO, audit logs, invoicing, security questionnaire.</td><td>Do we accept a 5-week investment to test $18k-35k ACV?</td></tr>
+        <tr><td><b>Full Enterprise</b></td><td>Custom retention, SCIM, SLA, CSM.</td><td>Do we have enough evidence for irreversible motion buildout?</td></tr>
+        <tr><td><b>Wait</b></td><td>Protect product roadmap.</td><td>What signal would change our mind?</td></tr>
+      </tbody></table>
+    </section>
+    <section class="mt-8 grid md:grid-cols-3 gap-5">
+      <div><div class="kicker">Approve</div><p class="mt-2 text-sm leading-6">Spec this week; find 3 design partners; report signed ACV by next review.</p></div>
+      <div><div class="kicker">Reject</div><p class="mt-2 text-sm leading-6">Continue self-serve; log requests; no procurement commitments.</p></div>
+      <div><div class="kicker">Need evidence</div><p class="mt-2 text-sm leading-6">Run 10 prospect calls and validate annual contract readiness.</p></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/exec-briefing-memo/assets/decision-command.html
+++ b/next/src/lib/templates/skills/exec-briefing-memo/assets/decision-command.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Executive Briefing Memo · Decision Command</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#101418;--panel:#171d22;--ink:#f1f5f9;--muted:#9aa8b8;--line:#2a343f;--green:#3ddc97;--red:#ff6b5f;--amber:#f0b45b}
+    body{margin:0;background:linear-gradient(135deg,#101418,#17202b);color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1180px;margin:auto;padding:38px 26px 56px}
+    .panel{background:rgba(23,29,34,.86);border:1px solid var(--line);border-radius:8px}.chip{font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.1em;border:1px solid var(--line);border-radius:999px;padding:6px 10px;color:var(--muted)}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:14px;text-align:left;font-size:13px;vertical-align:top}th{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.09em}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="panel p-7">
+      <div class="flex flex-wrap justify-between gap-3"><div class="flex gap-2 flex-wrap"><span class="chip">Decision command</span><span class="chip">Enterprise Plan</span><span class="chip">Deadline 2026-06-14</span></div><span class="chip text-[var(--amber)]">Medium-high confidence</span></div>
+      <div class="grid lg:grid-cols-[1fr_360px] gap-8 mt-8">
+        <div><div class="text-[var(--muted)] text-xs uppercase font-extrabold tracking-widest mb-3">Decision needed</div><h1 class="text-6xl font-extrabold leading-[.95]">Approve Enterprise Preview, not full Enterprise.</h1><p class="mt-5 text-lg text-[var(--muted)] leading-8">The signal is real enough to test annual contracts, but not strong enough to absorb full enterprise scope.</p></div>
+        <div class="panel p-5 bg-[#12251d]"><div class="text-[var(--green)] text-xs uppercase font-extrabold tracking-widest">Recommended path</div><ol class="mt-4 space-y-3 text-sm leading-6"><li><b>1.</b> Ship SSO + audit log MVP.</li><li><b>2.</b> Sell to 3 design partners.</li><li><b>3.</b> Defer custom retention until ACV proof.</li></ol></div>
+      </div>
+    </section>
+    <section class="grid md:grid-cols-4 gap-4 mt-5">
+      <div class="panel p-5"><div class="text-xs text-[var(--muted)] uppercase font-bold">Inbound asks</div><div class="text-5xl font-extrabold mt-3">18</div></div>
+      <div class="panel p-5"><div class="text-xs text-[var(--muted)] uppercase font-bold">Large accounts</div><div class="text-5xl font-extrabold mt-3">7</div></div>
+      <div class="panel p-5"><div class="text-xs text-[var(--muted)] uppercase font-bold">Est. ACV</div><div class="text-5xl font-extrabold mt-3">$18k+</div></div>
+      <div class="panel p-5"><div class="text-xs text-[var(--muted)] uppercase font-bold">Roadmap risk</div><div class="text-5xl font-extrabold mt-3 text-[var(--red)]">4-6w</div></div>
+    </section>
+    <section class="panel mt-5 overflow-hidden">
+      <table><thead><tr><th>Path</th><th>Upside</th><th>Cost</th><th>Kill criteria</th></tr></thead><tbody>
+        <tr><td><b>Preview</b></td><td>Tests willingness to pay.</td><td>5 weeks of scoped work.</td><td>No annual contracts from first 3 prospects.</td></tr>
+        <tr><td><b>Full enterprise</b></td><td>Bigger story.</td><td>Retention, SCIM, SLA, CSM.</td><td>Premature sales motion.</td></tr>
+        <tr><td><b>Wait</b></td><td>Protects roadmap.</td><td>Missed market pull.</td><td>Competitor captures segment.</td></tr>
+      </tbody></table>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/exec-briefing-memo/example.html
+++ b/next/src/lib/templates/skills/exec-briefing-memo/example.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Executive Briefing Memo · Board Paper</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@500;700;800&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--paper:#fbfaf6;--ink:#171717;--muted:#68635b;--line:#d8d0c3;--blue:#183b6b;--green:#216e4e}
+    body{margin:0;background:#ece7dc;color:var(--ink);font-family:Inter,system-ui,sans-serif}.sheet{max-width:980px;margin:34px auto;padding:48px 58px;background:var(--paper);box-shadow:0 24px 70px rgba(58,48,32,.18)}
+    .serif{font-family:"Source Serif 4",Georgia,serif}.kicker{font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.12em;color:var(--muted)}.rule{border-top:1px solid var(--ink);border-bottom:3px double var(--ink)}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top;font-size:13px}th{font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="sheet">
+    <header class="rule py-5">
+      <div class="kicker">Board decision paper · confidential</div>
+      <h1 class="serif mt-3 text-5xl leading-[.98] font-extrabold">Enterprise Plan: approve a narrow preview.</h1>
+      <p class="mt-4 text-sm text-[var(--muted)]">Owner: Maya Chen · Audience: CEO / CRO / CFO · Decision deadline: 2026-06-14</p>
+    </header>
+    <section class="grid md:grid-cols-[.75fr_1.25fr] gap-8 mt-7">
+      <aside>
+        <div class="kicker">Recommendation</div>
+        <p class="serif mt-3 text-2xl leading-8 font-bold text-[var(--green)]">Proceed with Enterprise Preview. Do not fund full enterprise scope yet.</p>
+      </aside>
+      <div class="space-y-4 text-sm leading-7">
+        <p><b>Why now:</b> 18 inbound requests in 45 days indicate real pull, including 7 accounts over 500 employees.</p>
+        <p><b>Constraint:</b> Current roadmap cost is meaningful; bank reconciliation may slip by 4-6 weeks.</p>
+        <p><b>Decision frame:</b> Treat enterprise as a pricing and packaging test, not a company-wide motion.</p>
+      </div>
+    </section>
+    <section class="mt-8">
+      <div class="kicker mb-3">Options analysis</div>
+      <table><thead><tr><th>Option</th><th>Rationale</th><th>Board question</th></tr></thead><tbody>
+        <tr><td><b>Enterprise Preview</b></td><td>SSO, audit logs, invoicing, security questionnaire.</td><td>Do we accept a 5-week investment to test $18k-35k ACV?</td></tr>
+        <tr><td><b>Full Enterprise</b></td><td>Custom retention, SCIM, SLA, CSM.</td><td>Do we have enough evidence for irreversible motion buildout?</td></tr>
+        <tr><td><b>Wait</b></td><td>Protect product roadmap.</td><td>What signal would change our mind?</td></tr>
+      </tbody></table>
+    </section>
+    <section class="mt-8 grid md:grid-cols-3 gap-5">
+      <div><div class="kicker">Approve</div><p class="mt-2 text-sm leading-6">Spec this week; find 3 design partners; report signed ACV by next review.</p></div>
+      <div><div class="kicker">Reject</div><p class="mt-2 text-sm leading-6">Continue self-serve; log requests; no procurement commitments.</p></div>
+      <div><div class="kicker">Need evidence</div><p class="mt-2 text-sm leading-6">Run 10 prospect calls and validate annual contract readiness.</p></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/exec-briefing-memo/example.html
+++ b/next/src/lib/templates/skills/exec-briefing-memo/example.html
@@ -3,46 +3,77 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Executive Briefing Memo · Board Paper</title>
+  <title>Executive Briefing Memo · Enterprise Plan</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@500;700;800&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
   <style>
-    :root{--paper:#fbfaf6;--ink:#171717;--muted:#68635b;--line:#d8d0c3;--blue:#183b6b;--green:#216e4e}
-    body{margin:0;background:#ece7dc;color:var(--ink);font-family:Inter,system-ui,sans-serif}.sheet{max-width:980px;margin:34px auto;padding:48px 58px;background:var(--paper);box-shadow:0 24px 70px rgba(58,48,32,.18)}
-    .serif{font-family:"Source Serif 4",Georgia,serif}.kicker{font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.12em;color:var(--muted)}.rule{border-top:1px solid var(--ink);border-bottom:3px double var(--ink)}
-    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top;font-size:13px}th{font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted)}
+    :root{--ink:#111827;--muted:#667085;--paper:#faf9f5;--line:#e4dfd4;--red:#a84332;--green:#1f7a58;--blue:#254f9c}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1120px;margin:0 auto;padding:40px 26px 54px}.box{border:1px solid var(--line);background:rgba(255,255,255,.72);border-radius:6px}
+    .label{font-size:11px;text-transform:uppercase;letter-spacing:.1em;font-weight:800;color:var(--muted)}.pill{border-radius:999px;padding:6px 10px;font-size:11px;font-weight:800}
+    table{width:100%;border-collapse:collapse} th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;vertical-align:top;font-size:13px} th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
   </style>
 </head>
 <body>
-  <main class="sheet">
-    <header class="rule py-5">
-      <div class="kicker">Board decision paper · confidential</div>
-      <h1 class="serif mt-3 text-5xl leading-[.98] font-extrabold">Enterprise Plan: approve a narrow preview.</h1>
-      <p class="mt-4 text-sm text-[var(--muted)]">Owner: Maya Chen · Audience: CEO / CRO / CFO · Decision deadline: 2026-06-14</p>
-    </header>
-    <section class="grid md:grid-cols-[.75fr_1.25fr] gap-8 mt-7">
-      <aside>
-        <div class="kicker">Recommendation</div>
-        <p class="serif mt-3 text-2xl leading-8 font-bold text-[var(--green)]">Proceed with Enterprise Preview. Do not fund full enterprise scope yet.</p>
-      </aside>
-      <div class="space-y-4 text-sm leading-7">
-        <p><b>Why now:</b> 18 inbound requests in 45 days indicate real pull, including 7 accounts over 500 employees.</p>
-        <p><b>Constraint:</b> Current roadmap cost is meaningful; bank reconciliation may slip by 4-6 weeks.</p>
-        <p><b>Decision frame:</b> Treat enterprise as a pricing and packaging test, not a company-wide motion.</p>
+  <main class="page">
+    <section class="box p-7">
+      <div class="flex flex-wrap justify-between gap-3 mb-8">
+        <div class="flex flex-wrap gap-2"><span class="pill bg-[#eef2ff] text-[var(--blue)]">Executive memo</span><span class="pill bg-white border border-[var(--line)]">Owner: Maya Chen</span><span class="pill bg-white border border-[var(--line)]">Deadline: 2026-06-14</span></div>
+        <div class="label">Audience: CEO / CRO / CFO</div>
+      </div>
+      <div class="grid lg:grid-cols-[1.15fr_.85fr] gap-8">
+        <div>
+          <div class="label mb-2">Decision needed</div>
+          <h1 class="text-5xl md:text-6xl font-extrabold leading-[.95] tracking-tight">Should FlowLedger launch an Enterprise Plan in Q3?</h1>
+        </div>
+        <div class="box p-5 bg-[#f0f8f4]">
+          <div class="label mb-3 text-[var(--green)]">Recommendation</div>
+          <h2 class="text-2xl font-extrabold">Approve a narrow Enterprise Preview.</h2>
+          <p class="mt-3 text-sm leading-6 text-[var(--muted)]">Build SSO, audit logs, annual invoicing, and a security questionnaire motion. Defer custom retention and full enterprise operations.</p>
+          <div class="mt-5 flex gap-2"><span class="pill bg-white text-[var(--green)] border border-[#badbcc]">Confidence: medium-high</span><span class="pill bg-white text-[var(--ink)] border border-[var(--line)]">Reversible</span></div>
+        </div>
       </div>
     </section>
-    <section class="mt-8">
-      <div class="kicker mb-3">Options analysis</div>
-      <table><thead><tr><th>Option</th><th>Rationale</th><th>Board question</th></tr></thead><tbody>
-        <tr><td><b>Enterprise Preview</b></td><td>SSO, audit logs, invoicing, security questionnaire.</td><td>Do we accept a 5-week investment to test $18k-35k ACV?</td></tr>
-        <tr><td><b>Full Enterprise</b></td><td>Custom retention, SCIM, SLA, CSM.</td><td>Do we have enough evidence for irreversible motion buildout?</td></tr>
-        <tr><td><b>Wait</b></td><td>Protect product roadmap.</td><td>What signal would change our mind?</td></tr>
-      </tbody></table>
+
+    <section class="grid md:grid-cols-4 gap-4 mt-5">
+      <div class="box p-5"><div class="label">Enterprise asks</div><div class="mt-2 text-4xl font-extrabold">18</div><p class="text-sm text-[var(--muted)] mt-2">inbound requests in 45 days</p></div>
+      <div class="box p-5"><div class="label">Large accounts</div><div class="mt-2 text-4xl font-extrabold">7</div><p class="text-sm text-[var(--muted)] mt-2">over 500 employees</p></div>
+      <div class="box p-5"><div class="label">Potential ACV</div><div class="mt-2 text-4xl font-extrabold">$18k-35k</div><p class="text-sm text-[var(--muted)] mt-2">sales estimate, not proven</p></div>
+      <div class="box p-5"><div class="label">Roadmap cost</div><div class="mt-2 text-4xl font-extrabold">4-6w</div><p class="text-sm text-[var(--muted)] mt-2">delay risk to bank reconciliation</p></div>
     </section>
-    <section class="mt-8 grid md:grid-cols-3 gap-5">
-      <div><div class="kicker">Approve</div><p class="mt-2 text-sm leading-6">Spec this week; find 3 design partners; report signed ACV by next review.</p></div>
-      <div><div class="kicker">Reject</div><p class="mt-2 text-sm leading-6">Continue self-serve; log requests; no procurement commitments.</p></div>
-      <div><div class="kicker">Need evidence</div><p class="mt-2 text-sm leading-6">Run 10 prospect calls and validate annual contract readiness.</p></div>
+
+    <section class="grid lg:grid-cols-[1.1fr_.9fr] gap-5 mt-5">
+      <div class="box overflow-hidden">
+        <div class="p-5 border-b border-[var(--line)]"><div class="label">Tradeoff table</div></div>
+        <table>
+          <thead><tr><th>Option</th><th>Upside</th><th>Cost</th><th>Risk</th><th>Reversibility</th></tr></thead>
+          <tbody>
+            <tr><td><b>No enterprise in 2026</b></td><td>Protects roadmap focus</td><td>Leaves 18 asks unanswered</td><td>Missed market signal</td><td>Medium</td></tr>
+            <tr><td><b>Enterprise Preview</b></td><td>Tests willingness to pay</td><td>5 weeks for SSO + audit logs</td><td>Support load</td><td>High</td></tr>
+            <tr><td><b>Full Enterprise Plan</b></td><td>Stronger enterprise story</td><td>Retention, SCIM, SLA, CSM</td><td>Premature motion</td><td>Low</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="box p-5">
+        <div class="label mb-4">Risks & mitigations</div>
+        <div class="space-y-4 text-sm leading-6">
+          <p><b>Enterprise distraction:</b> cap scope to SSO, audit logs, annual invoicing, and security questionnaire.</p>
+          <p><b>Pricing uncertainty:</b> sell as preview to first 3 annual prospects before expanding scope.</p>
+          <p><b>Support readiness:</b> create one security questionnaire owner and canned response library.</p>
+          <p><b>Roadmap delay:</b> explicitly defer custom retention until ACV evidence exists.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="box p-6 mt-5">
+      <div class="label mb-4">Decision path</div>
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="border-l-4 border-[var(--green)] pl-4"><h3 class="font-extrabold">Approve</h3><p class="text-sm text-[var(--muted)] mt-2">Start Enterprise Preview spec this week; sales identifies 3 design partners.</p></div>
+        <div class="border-l-4 border-[var(--red)] pl-4"><h3 class="font-extrabold">Reject</h3><p class="text-sm text-[var(--muted)] mt-2">Keep self-serve roadmap; log enterprise asks but avoid custom commitments.</p></div>
+        <div class="border-l-4 border-[var(--blue)] pl-4"><h3 class="font-extrabold">Need evidence</h3><p class="text-sm text-[var(--muted)] mt-2">Run 10 prospect calls and validate annual contract willingness by June 14.</p></div>
+      </div>
     </section>
   </main>
 </body>

--- a/next/src/lib/templates/skills/exec-briefing-memo/example.md
+++ b/next/src/lib/templates/skills/exec-briefing-memo/example.md
@@ -1,0 +1,26 @@
+# Executive Briefing Memo Input
+
+Topic: Should FlowLedger launch an Enterprise Plan in Q3?
+Owner: Maya Chen, Head of Product
+Audience: CEO, CRO, CFO
+Decision deadline: 2026-06-14
+
+## Context
+FlowLedger is a finance automation product for 20-200 person companies. Current pricing is self-serve: Starter $49/mo, Growth $199/mo, Scale $499/mo.
+
+## Signals
+- Sales: 18 inbound requests in the last 45 days asked for SSO, audit logs, custom retention, and procurement docs.
+- Sales: 7 of those accounts had more than 500 employees. 3 explicitly asked whether we support annual contracts.
+- Product: SSO is estimated at 3 engineering weeks. Audit log MVP is 2 weeks. Custom retention is unknown because current data model assumes one retention policy per workspace.
+- Support: Larger prospects ask more security questions, but current support team has no security questionnaire process.
+- Finance: Current average self-serve ACV is about $2.8k. Sales believes enterprise ACV could land between $18k and $35k if security basics exist.
+- Risk: Enterprise work may delay the Q3 bank reconciliation roadmap by 4-6 weeks.
+- Customer quote: "We like the workflow, but procurement will not approve this without SSO and audit logs."
+
+## Options discussed
+1. Do not launch enterprise plan this year.
+2. Launch a narrow Enterprise Preview with SSO, audit logs, annual invoicing, and security questionnaire support.
+3. Build a full Enterprise Plan with custom retention, SCIM, dedicated CSM, SLA, and admin analytics.
+
+## Leadership concern
+CEO wants to know whether this is a real market pull or sales distraction. CFO wants to avoid building an enterprise motion before pricing is proven.

--- a/next/src/lib/templates/skills/experiment-readout/SKILL.md
+++ b/next/src/lib/templates/skills/experiment-readout/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: experiment-readout
+zh_name: "实验复盘"
+en_name: "Experiment Readout"
+emoji: "🧪"
+description: "假设 + 指标 + 结果 + 解释 + 决策, 把 A/B 或产品实验转成行动建议"
+category: data
+scenario: product
+aspect_hint: "产品实验报告"
+featured: 8
+tags: ["experiment", "ab-test", "growth", "product", "data", "实验", "复盘"]
+example_id: sample-experiment-readout
+example_name: "实验复盘 · Onboarding Checklist"
+example_format: markdown
+example_tagline: "不是展示数据, 而是判断上线/停止/继续"
+example_desc: "把实验假设、样本、指标和结果转成产品决策报告。"
+---
+
+【模板: 实验复盘 / Experiment Readout】
+【意图】这不是普通数据报告、不是 dashboard。目标是回答: "这个实验说明了什么, 我们下一步应该上线、停止、继续跑, 还是重新设计?"
+
+【适合输入】
+- A/B test、增长实验、定价实验、onboarding 改版、功能灰度、邮件实验
+- 可以是 markdown、CSV、表格粘贴或混合记录
+
+【必须输出的结构】
+1. Header: 实验名称、owner、日期、实验状态、decision。
+2. Hypothesis: 原始假设, 必须改写成可验证句式。
+3. Setup: audience、variant、duration、sample size、primary metric、guardrail metrics。
+4. Result snapshot: primary metric lift、absolute delta、sample、confidence / caveat。
+5. Metric table: Control vs Variant, primary + secondary + guardrail。
+6. Interpretation: 解释结果为什么发生, 区分 signal、noise、unknown。
+7. Decision: Ship / iterate / extend / stop 四选一, 并给理由。
+8. Follow-up experiments: 2-4 个下一步实验, 每个包含 hypothesis、expected impact、effort。
+9. Instrumentation notes: 数据缺口、埋点问题、样本偏差。
+
+【设计要求】
+- 产品数据团队风格: 清楚、可信、行动导向。
+- 首屏必须有大号 decision badge 和 primary metric delta。
+- 图表可以用 CSS/SVG/Chart.js; 如果用 Chart.js, canvas 外层必须固定高度。
+- 不要把结果包装得过度确定; 小样本或缺少显著性时必须明确 caveat。
+
+【可选风格模板 — 参考 assets/】
+根据实验语境选择一种, 不要三种混用:
+- `assets/product-readout.html`: 默认风格。浅色产品实验复盘, 适合 PM / growth / leadership readout。
+- `assets/lab-notebook.html`: 研究实验室 notebook, 适合 early-stage experiment、定性 + 定量混合、需要保留 caveat 的探索实验。
+- `assets/growth-console.html`: 深色 growth analytics console, 适合增长团队、实时指标、漏斗 / activation / conversion readout。
+
+如果用户没有指定风格, 优先使用 `product-readout`; 如果材料强调研究过程和不确定性, 使用 `lab-notebook`; 如果材料强调增长指标、漏斗、实时监控或运营节奏, 使用 `growth-console`。
+
+【内容真实性】
+- 只使用用户提供的数据。不要捏造 p-value、confidence、样本量。
+- 如果没有统计显著性信息, 用 "directional" / "inconclusive" / "needs more data" 表达。

--- a/next/src/lib/templates/skills/experiment-readout/assets/growth-console.html
+++ b/next/src/lib/templates/skills/experiment-readout/assets/growth-console.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Experiment Readout · Growth Console</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#07130f;--panel:#0e2119;--line:#1e3a30;--ink:#eefcf5;--muted:#93b5a7;--green:#2ff29a;--red:#ff6d6d;--blue:#64a7ff}
+    body{margin:0;background:radial-gradient(circle at 80% 0,#164632,#07130f 50%);color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1180px;margin:auto;padding:38px 26px 56px}
+    .panel{border:1px solid var(--line);background:rgba(14,33,25,.82);border-radius:8px}.chip{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:11px;text-transform:uppercase;letter-spacing:.1em;font-weight:800;color:var(--muted)}
+    .bar{height:10px;border-radius:999px;background:#17352a;overflow:hidden}.bar span{display:block;height:100%;background:var(--green);border-radius:999px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;font-size:13px}th{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="panel p-7">
+      <div class="flex flex-wrap justify-between gap-3"><div class="flex gap-2 flex-wrap"><span class="chip">Growth console</span><span class="chip">Onboarding checklist</span></div><span class="chip text-[var(--green)]">Decision: iterate + 50%</span></div>
+      <div class="grid lg:grid-cols-[1fr_380px] gap-8 mt-8">
+        <div><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--muted)] mb-3">Primary readout</div><h1 class="text-6xl font-extrabold leading-[.94]">Activation is up. Friction is up too.</h1><p class="mt-5 text-lg leading-8 text-[var(--muted)]">The variant increases activation and teammate invites, while slightly raising support load around data-source setup.</p></div>
+        <div class="panel p-5"><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--green)]">Primary metric</div><div class="mt-2 text-7xl font-extrabold">+5.5pp</div><p class="text-sm text-[var(--muted)] mt-2">21.4% control → 26.9% variant</p></div>
+      </div>
+    </section>
+    <section class="grid lg:grid-cols-[.9fr_1.1fr] gap-5 mt-5">
+      <div class="panel p-5 space-y-5">
+        <div><div class="flex justify-between text-sm mb-2"><b>Control activation</b><span>21.4%</span></div><div class="bar"><span style="width:21.4%"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Variant activation</b><span>26.9%</span></div><div class="bar"><span style="width:26.9%"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Control invite</b><span>38.1%</span></div><div class="bar"><span style="width:38.1%;background:var(--blue)"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Variant invite</b><span>47.4%</span></div><div class="bar"><span style="width:47.4%;background:var(--blue)"></span></div></div>
+      </div>
+      <div class="panel overflow-hidden">
+        <table><thead><tr><th>Signal</th><th>Read</th><th>Action</th></tr></thead><tbody>
+          <tr><td><b>Activation lift</b></td><td class="text-[var(--green)]">Positive</td><td>Expand to 50%</td></tr>
+          <tr><td><b>Support tickets</b></td><td class="text-[var(--red)]">Watch</td><td>Add skip/connect-later option</td></tr>
+          <tr><td><b>Deletion</b></td><td>Flat</td><td>No rollback needed</td></tr>
+        </tbody></table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/experiment-readout/assets/lab-notebook.html
+++ b/next/src/lib/templates/skills/experiment-readout/assets/lab-notebook.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Experiment Readout · Lab Notebook</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--paper:#fffdf5;--ink:#17211b;--muted:#65746b;--line:#d8dece;--green:#16865a;--amber:#b7791f}
+    body{margin:0;background:#edf3ea;color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1080px;margin:34px auto;padding:0 24px 54px}.sheet{background:var(--paper);border:1px solid var(--line);box-shadow:0 18px 50px rgba(47,64,45,.14)}
+    .mono{font-family:"IBM Plex Mono",monospace}.label{font-size:11px;text-transform:uppercase;letter-spacing:.12em;font-weight:800;color:var(--muted)}.line{background-image:linear-gradient(var(--line) 1px,transparent 1px);background-size:100% 34px}
+    table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;font-size:13px}th{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="sheet line p-8">
+      <div class="flex flex-wrap justify-between gap-3"><div class="mono text-sm">EXP-042 · onboarding-checklist</div><div class="label">Growth lab notebook</div></div>
+      <h1 class="mt-8 text-5xl font-extrabold leading-[.98]">Result: iterate before full rollout.</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-[var(--muted)]">The checklist appears to improve activation, but the data-source step adds support friction and the test lacks formal significance calculation.</p>
+      <div class="grid md:grid-cols-3 gap-4 mt-8">
+        <div class="bg-white/70 border border-[var(--line)] p-4"><div class="label">Primary lift</div><div class="text-4xl font-extrabold mt-2 text-[var(--green)]">+5.5pp</div></div>
+        <div class="bg-white/70 border border-[var(--line)] p-4"><div class="label">Samples</div><div class="text-4xl font-extrabold mt-2">3641</div></div>
+        <div class="bg-white/70 border border-[var(--line)] p-4"><div class="label">Caveat</div><div class="text-2xl font-extrabold mt-3 text-[var(--amber)]">Directional</div></div>
+      </div>
+    </section>
+    <section class="sheet mt-5 overflow-hidden">
+      <table><thead><tr><th>Metric</th><th>Control</th><th>Variant</th><th>Interpretation</th></tr></thead><tbody>
+        <tr><td><b>Activation</b></td><td>21.4%</td><td>26.9%</td><td>Positive signal</td></tr>
+        <tr><td><b>Invite teammate</b></td><td>38.1%</td><td>47.4%</td><td>Main driver</td></tr>
+        <tr><td><b>Support tickets</b></td><td>6.2</td><td>7.1</td><td>Friction introduced</td></tr>
+      </tbody></table>
+    </section>
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <div class="sheet p-5"><div class="label">Next experiment</div><p class="mt-3 text-sm leading-6">Split "connect data source" into "skip now" and "connect later."</p></div>
+      <div class="sheet p-5"><div class="label">Instrumentation</div><p class="mt-3 text-sm leading-6">Calculate p-value or Bayesian posterior before 100% rollout.</p></div>
+      <div class="sheet p-5"><div class="label">Decision</div><p class="mt-3 text-sm leading-6">Ship to 50% with friction fix and support monitoring.</p></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/experiment-readout/assets/product-readout.html
+++ b/next/src/lib/templates/skills/experiment-readout/assets/product-readout.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Experiment Readout · Onboarding Checklist</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--ink:#102027;--muted:#667085;--paper:#f3f7f4;--line:#dbe5dd;--green:#16865a;--amber:#b7791f;--blue:#2563eb}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1160px;margin:0 auto;padding:40px 26px 56px}.card{border:1px solid var(--line);background:rgba(255,255,255,.76);border-radius:6px}
+    .label{font-size:11px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}.pill{border-radius:999px;padding:6px 10px;font-size:11px;font-weight:800}
+    table{width:100%;border-collapse:collapse} th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;font-size:13px} th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .bar{height:12px;border-radius:999px;background:#e5ebe7;overflow:hidden}.bar span{display:block;height:100%;border-radius:999px;background:var(--green)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="card p-7">
+      <div class="flex flex-wrap justify-between gap-3 mb-7">
+        <div class="flex flex-wrap gap-2"><span class="pill bg-[#e8f8ef] text-[var(--green)]">Experiment readout</span><span class="pill bg-white border border-[var(--line)]">2026-05-06 → 2026-05-20</span><span class="pill bg-white border border-[var(--line)]">Owner: Growth PM</span></div>
+        <span class="pill bg-[#fff7e6] text-[var(--amber)]">Directional, no p-value yet</span>
+      </div>
+      <div class="grid md:grid-cols-[1fr_340px] gap-8 items-end">
+        <div>
+          <div class="label mb-2">Decision</div>
+          <h1 class="text-5xl md:text-6xl font-extrabold leading-[.95] tracking-tight">Iterate and ship to 50%.</h1>
+          <p class="mt-5 text-lg leading-8 text-[var(--muted)] max-w-3xl">The onboarding checklist increased 7-day activation by 5.5 absolute points, mostly through teammate invites. The data-source step created support friction and should be softened before full rollout.</p>
+        </div>
+        <div class="card p-5 bg-[#eefbf4]">
+          <div class="label text-[var(--green)]">Primary metric</div>
+          <div class="mt-2 text-6xl font-extrabold">+5.5pp</div>
+          <p class="mt-2 text-sm text-[var(--muted)]">Activation within 7 days: 21.4% → 26.9%</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <div class="card p-5"><div class="label">Hypothesis</div><p class="mt-3 text-sm leading-6">A guided checklist will help new teams invite teammates and complete a first shared workflow.</p></div>
+      <div class="card p-5"><div class="label">Audience</div><p class="mt-3 text-sm leading-6">New workspaces with 2-20 invited users.</p></div>
+      <div class="card p-5"><div class="label">Guardrails</div><p class="mt-3 text-sm leading-6">Support tickets rose from 6.2 to 7.1 per 100 workspaces; deletion stayed flat.</p></div>
+    </section>
+
+    <section class="grid lg:grid-cols-[1.05fr_.95fr] gap-5 mt-5">
+      <div class="card overflow-hidden">
+        <div class="p-5 border-b border-[var(--line)]"><div class="label">Metric table</div></div>
+        <table>
+          <thead><tr><th>Metric</th><th>Control</th><th>Variant</th><th>Read</th></tr></thead>
+          <tbody>
+            <tr><td><b>Activation</b></td><td>21.4%</td><td>26.9%</td><td class="text-[var(--green)] font-bold">Positive signal</td></tr>
+            <tr><td><b>Invite teammate</b></td><td>38.1%</td><td>47.4%</td><td>Largest movement</td></tr>
+            <tr><td><b>Create workflow</b></td><td>44.8%</td><td>46.1%</td><td>Minor lift</td></tr>
+            <tr><td><b>Support tickets / 100</b></td><td>6.2</td><td>7.1</td><td class="text-[var(--amber)] font-bold">Watch</td></tr>
+            <tr><td><b>Workspace deletion</b></td><td>4.8%</td><td>5.0%</td><td>Flat guardrail</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="card p-5">
+        <div class="label mb-5">Activation funnel movement</div>
+        <div class="space-y-5">
+          <div><div class="flex justify-between text-sm mb-2"><b>Control activation</b><span>21.4%</span></div><div class="bar"><span style="width:21.4%"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Variant activation</b><span>26.9%</span></div><div class="bar"><span style="width:26.9%"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Control invite</b><span>38.1%</span></div><div class="bar"><span style="width:38.1%;background:var(--blue)"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Variant invite</b><span>47.4%</span></div><div class="bar"><span style="width:47.4%;background:var(--blue)"></span></div></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="card p-5"><span class="pill bg-[#e8f8ef] text-[var(--green)]">Ship next</span><h3 class="mt-4 text-xl font-extrabold">Roll out to 50%</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Keep checklist visible, but reduce pressure around data-source connection.</p></article>
+      <article class="card p-5"><span class="pill bg-[#fff7e6] text-[var(--amber)]">Fix friction</span><h3 class="mt-4 text-xl font-extrabold">Split data-source step</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add "skip for now" and "connect later"; engineering estimates 2 days.</p></article>
+      <article class="card p-5"><span class="pill bg-[#eef2ff] text-[var(--blue)]">Measure</span><h3 class="mt-4 text-xl font-extrabold">Calculate significance</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add p-value or Bayesian read before 100% rollout.</p></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/experiment-readout/example.html
+++ b/next/src/lib/templates/skills/experiment-readout/example.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Experiment Readout · Growth Console</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#07130f;--panel:#0e2119;--line:#1e3a30;--ink:#eefcf5;--muted:#93b5a7;--green:#2ff29a;--red:#ff6d6d;--blue:#64a7ff}
+    body{margin:0;background:radial-gradient(circle at 80% 0,#164632,#07130f 50%);color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1180px;margin:auto;padding:38px 26px 56px}
+    .panel{border:1px solid var(--line);background:rgba(14,33,25,.82);border-radius:8px}.chip{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:11px;text-transform:uppercase;letter-spacing:.1em;font-weight:800;color:var(--muted)}
+    .bar{height:10px;border-radius:999px;background:#17352a;overflow:hidden}.bar span{display:block;height:100%;background:var(--green);border-radius:999px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;font-size:13px}th{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="panel p-7">
+      <div class="flex flex-wrap justify-between gap-3"><div class="flex gap-2 flex-wrap"><span class="chip">Growth console</span><span class="chip">Onboarding checklist</span></div><span class="chip text-[var(--green)]">Decision: iterate + 50%</span></div>
+      <div class="grid lg:grid-cols-[1fr_380px] gap-8 mt-8">
+        <div><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--muted)] mb-3">Primary readout</div><h1 class="text-6xl font-extrabold leading-[.94]">Activation is up. Friction is up too.</h1><p class="mt-5 text-lg leading-8 text-[var(--muted)]">The variant increases activation and teammate invites, while slightly raising support load around data-source setup.</p></div>
+        <div class="panel p-5"><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--green)]">Primary metric</div><div class="mt-2 text-7xl font-extrabold">+5.5pp</div><p class="text-sm text-[var(--muted)] mt-2">21.4% control → 26.9% variant</p></div>
+      </div>
+    </section>
+    <section class="grid lg:grid-cols-[.9fr_1.1fr] gap-5 mt-5">
+      <div class="panel p-5 space-y-5">
+        <div><div class="flex justify-between text-sm mb-2"><b>Control activation</b><span>21.4%</span></div><div class="bar"><span style="width:21.4%"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Variant activation</b><span>26.9%</span></div><div class="bar"><span style="width:26.9%"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Control invite</b><span>38.1%</span></div><div class="bar"><span style="width:38.1%;background:var(--blue)"></span></div></div>
+        <div><div class="flex justify-between text-sm mb-2"><b>Variant invite</b><span>47.4%</span></div><div class="bar"><span style="width:47.4%;background:var(--blue)"></span></div></div>
+      </div>
+      <div class="panel overflow-hidden">
+        <table><thead><tr><th>Signal</th><th>Read</th><th>Action</th></tr></thead><tbody>
+          <tr><td><b>Activation lift</b></td><td class="text-[var(--green)]">Positive</td><td>Expand to 50%</td></tr>
+          <tr><td><b>Support tickets</b></td><td class="text-[var(--red)]">Watch</td><td>Add skip/connect-later option</td></tr>
+          <tr><td><b>Deletion</b></td><td>Flat</td><td>No rollback needed</td></tr>
+        </tbody></table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/next/src/lib/templates/skills/experiment-readout/example.html
+++ b/next/src/lib/templates/skills/experiment-readout/example.html
@@ -3,39 +3,76 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Experiment Readout · Growth Console</title>
+  <title>Experiment Readout · Onboarding Checklist</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;800&display=swap" rel="stylesheet">
   <style>
-    :root{--bg:#07130f;--panel:#0e2119;--line:#1e3a30;--ink:#eefcf5;--muted:#93b5a7;--green:#2ff29a;--red:#ff6d6d;--blue:#64a7ff}
-    body{margin:0;background:radial-gradient(circle at 80% 0,#164632,#07130f 50%);color:var(--ink);font-family:Inter,system-ui,sans-serif}.page{max-width:1180px;margin:auto;padding:38px 26px 56px}
-    .panel{border:1px solid var(--line);background:rgba(14,33,25,.82);border-radius:8px}.chip{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:11px;text-transform:uppercase;letter-spacing:.1em;font-weight:800;color:var(--muted)}
-    .bar{height:10px;border-radius:999px;background:#17352a;overflow:hidden}.bar span{display:block;height:100%;background:var(--green);border-radius:999px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;font-size:13px}th{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+    :root{--ink:#102027;--muted:#667085;--paper:#f3f7f4;--line:#dbe5dd;--green:#16865a;--amber:#b7791f;--blue:#2563eb}
+    *{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);font-family:Inter,"Noto Sans SC",system-ui,sans-serif}
+    .page{max-width:1160px;margin:0 auto;padding:40px 26px 56px}.card{border:1px solid var(--line);background:rgba(255,255,255,.76);border-radius:6px}
+    .label{font-size:11px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}.pill{border-radius:999px;padding:6px 10px;font-size:11px;font-weight:800}
+    table{width:100%;border-collapse:collapse} th,td{border-bottom:1px solid var(--line);padding:13px;text-align:left;font-size:13px} th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .bar{height:12px;border-radius:999px;background:#e5ebe7;overflow:hidden}.bar span{display:block;height:100%;border-radius:999px;background:var(--green)}
   </style>
 </head>
 <body>
   <main class="page">
-    <section class="panel p-7">
-      <div class="flex flex-wrap justify-between gap-3"><div class="flex gap-2 flex-wrap"><span class="chip">Growth console</span><span class="chip">Onboarding checklist</span></div><span class="chip text-[var(--green)]">Decision: iterate + 50%</span></div>
-      <div class="grid lg:grid-cols-[1fr_380px] gap-8 mt-8">
-        <div><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--muted)] mb-3">Primary readout</div><h1 class="text-6xl font-extrabold leading-[.94]">Activation is up. Friction is up too.</h1><p class="mt-5 text-lg leading-8 text-[var(--muted)]">The variant increases activation and teammate invites, while slightly raising support load around data-source setup.</p></div>
-        <div class="panel p-5"><div class="text-xs uppercase tracking-widest font-extrabold text-[var(--green)]">Primary metric</div><div class="mt-2 text-7xl font-extrabold">+5.5pp</div><p class="text-sm text-[var(--muted)] mt-2">21.4% control → 26.9% variant</p></div>
+    <section class="card p-7">
+      <div class="flex flex-wrap justify-between gap-3 mb-7">
+        <div class="flex flex-wrap gap-2"><span class="pill bg-[#e8f8ef] text-[var(--green)]">Experiment readout</span><span class="pill bg-white border border-[var(--line)]">2026-05-06 → 2026-05-20</span><span class="pill bg-white border border-[var(--line)]">Owner: Growth PM</span></div>
+        <span class="pill bg-[#fff7e6] text-[var(--amber)]">Directional, no p-value yet</span>
+      </div>
+      <div class="grid md:grid-cols-[1fr_340px] gap-8 items-end">
+        <div>
+          <div class="label mb-2">Decision</div>
+          <h1 class="text-5xl md:text-6xl font-extrabold leading-[.95] tracking-tight">Iterate and ship to 50%.</h1>
+          <p class="mt-5 text-lg leading-8 text-[var(--muted)] max-w-3xl">The onboarding checklist increased 7-day activation by 5.5 absolute points, mostly through teammate invites. The data-source step created support friction and should be softened before full rollout.</p>
+        </div>
+        <div class="card p-5 bg-[#eefbf4]">
+          <div class="label text-[var(--green)]">Primary metric</div>
+          <div class="mt-2 text-6xl font-extrabold">+5.5pp</div>
+          <p class="mt-2 text-sm text-[var(--muted)]">Activation within 7 days: 21.4% → 26.9%</p>
+        </div>
       </div>
     </section>
-    <section class="grid lg:grid-cols-[.9fr_1.1fr] gap-5 mt-5">
-      <div class="panel p-5 space-y-5">
-        <div><div class="flex justify-between text-sm mb-2"><b>Control activation</b><span>21.4%</span></div><div class="bar"><span style="width:21.4%"></span></div></div>
-        <div><div class="flex justify-between text-sm mb-2"><b>Variant activation</b><span>26.9%</span></div><div class="bar"><span style="width:26.9%"></span></div></div>
-        <div><div class="flex justify-between text-sm mb-2"><b>Control invite</b><span>38.1%</span></div><div class="bar"><span style="width:38.1%;background:var(--blue)"></span></div></div>
-        <div><div class="flex justify-between text-sm mb-2"><b>Variant invite</b><span>47.4%</span></div><div class="bar"><span style="width:47.4%;background:var(--blue)"></span></div></div>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <div class="card p-5"><div class="label">Hypothesis</div><p class="mt-3 text-sm leading-6">A guided checklist will help new teams invite teammates and complete a first shared workflow.</p></div>
+      <div class="card p-5"><div class="label">Audience</div><p class="mt-3 text-sm leading-6">New workspaces with 2-20 invited users.</p></div>
+      <div class="card p-5"><div class="label">Guardrails</div><p class="mt-3 text-sm leading-6">Support tickets rose from 6.2 to 7.1 per 100 workspaces; deletion stayed flat.</p></div>
+    </section>
+
+    <section class="grid lg:grid-cols-[1.05fr_.95fr] gap-5 mt-5">
+      <div class="card overflow-hidden">
+        <div class="p-5 border-b border-[var(--line)]"><div class="label">Metric table</div></div>
+        <table>
+          <thead><tr><th>Metric</th><th>Control</th><th>Variant</th><th>Read</th></tr></thead>
+          <tbody>
+            <tr><td><b>Activation</b></td><td>21.4%</td><td>26.9%</td><td class="text-[var(--green)] font-bold">Positive signal</td></tr>
+            <tr><td><b>Invite teammate</b></td><td>38.1%</td><td>47.4%</td><td>Largest movement</td></tr>
+            <tr><td><b>Create workflow</b></td><td>44.8%</td><td>46.1%</td><td>Minor lift</td></tr>
+            <tr><td><b>Support tickets / 100</b></td><td>6.2</td><td>7.1</td><td class="text-[var(--amber)] font-bold">Watch</td></tr>
+            <tr><td><b>Workspace deletion</b></td><td>4.8%</td><td>5.0%</td><td>Flat guardrail</td></tr>
+          </tbody>
+        </table>
       </div>
-      <div class="panel overflow-hidden">
-        <table><thead><tr><th>Signal</th><th>Read</th><th>Action</th></tr></thead><tbody>
-          <tr><td><b>Activation lift</b></td><td class="text-[var(--green)]">Positive</td><td>Expand to 50%</td></tr>
-          <tr><td><b>Support tickets</b></td><td class="text-[var(--red)]">Watch</td><td>Add skip/connect-later option</td></tr>
-          <tr><td><b>Deletion</b></td><td>Flat</td><td>No rollback needed</td></tr>
-        </tbody></table>
+      <div class="card p-5">
+        <div class="label mb-5">Activation funnel movement</div>
+        <div class="space-y-5">
+          <div><div class="flex justify-between text-sm mb-2"><b>Control activation</b><span>21.4%</span></div><div class="bar"><span style="width:21.4%"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Variant activation</b><span>26.9%</span></div><div class="bar"><span style="width:26.9%"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Control invite</b><span>38.1%</span></div><div class="bar"><span style="width:38.1%;background:var(--blue)"></span></div></div>
+          <div><div class="flex justify-between text-sm mb-2"><b>Variant invite</b><span>47.4%</span></div><div class="bar"><span style="width:47.4%;background:var(--blue)"></span></div></div>
+        </div>
       </div>
+    </section>
+
+    <section class="grid md:grid-cols-3 gap-4 mt-5">
+      <article class="card p-5"><span class="pill bg-[#e8f8ef] text-[var(--green)]">Ship next</span><h3 class="mt-4 text-xl font-extrabold">Roll out to 50%</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Keep checklist visible, but reduce pressure around data-source connection.</p></article>
+      <article class="card p-5"><span class="pill bg-[#fff7e6] text-[var(--amber)]">Fix friction</span><h3 class="mt-4 text-xl font-extrabold">Split data-source step</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add "skip for now" and "connect later"; engineering estimates 2 days.</p></article>
+      <article class="card p-5"><span class="pill bg-[#eef2ff] text-[var(--blue)]">Measure</span><h3 class="mt-4 text-xl font-extrabold">Calculate significance</h3><p class="mt-3 text-sm leading-6 text-[var(--muted)]">Add p-value or Bayesian read before 100% rollout.</p></article>
     </section>
   </main>
 </body>

--- a/next/src/lib/templates/skills/experiment-readout/example.md
+++ b/next/src/lib/templates/skills/experiment-readout/example.md
@@ -1,0 +1,40 @@
+# Experiment Readout Input
+
+Experiment: Onboarding checklist for new team workspaces
+Owner: Growth PM
+Dates: 2026-05-06 to 2026-05-20
+Audience: New workspaces with 2-20 invited users
+
+## Hypothesis
+If we show a guided onboarding checklist after workspace creation, more teams will invite teammates and complete their first shared workflow within 7 days.
+
+## Variants
+- Control: Current empty dashboard with "Create workflow" button.
+- Variant: Checklist with four steps: invite teammates, connect data source, create first workflow, schedule weekly digest.
+
+## Metrics
+Primary metric: Activation within 7 days, defined as "created a workflow and invited at least one teammate."
+Guardrails: support tickets per workspace, workspace deletion within 7 days.
+
+## Results
+Control:
+- Sample: 1,842 workspaces
+- Activation: 21.4%
+- Invite teammate: 38.1%
+- Create workflow: 44.8%
+- Support tickets per 100 workspaces: 6.2
+- Workspace deletion: 4.8%
+
+Variant:
+- Sample: 1,799 workspaces
+- Activation: 26.9%
+- Invite teammate: 47.4%
+- Create workflow: 46.1%
+- Support tickets per 100 workspaces: 7.1
+- Workspace deletion: 5.0%
+
+Notes:
+- No formal p-value was calculated yet.
+- Qualitative feedback says checklist made the product feel "less empty."
+- Support saw more questions about connecting data sources.
+- Engineering says data-source step can be split into "skip for now" and "connect later" in 2 days.


### PR DESCRIPTION
## Summary

Adds three decision-oriented skill templates:

- `competitive-teardown`
- `exec-briefing-memo`
- `experiment-readout`

Each skill includes example input, example HTML, and multiple style assets under `assets/`.

## Why

The current skill catalog has strong coverage for decks, dashboards, social cards, articles, and visual publishing formats. These additions focus on business and product decision workflows:

- external competitor analysis
- internal executive decision memos
- product experiment readouts

## Details

- `competitive-teardown`: positioning map, competitor cards, feature matrix, pricing read, opportunity windows, and recommended moves.
- `exec-briefing-memo`: decision needed, recommendation, evidence, tradeoffs, risks, and decision path.
- `experiment-readout`: hypothesis, setup, metric table, interpretation, decision, and follow-up experiments.

Each skill includes three related visual styles in `assets/` so the output can match the decision context instead of reusing a single generic report style.

## Verification

- Rendered all 9 `assets/*.html` style templates locally in Chrome.
- Confirmed each skill includes `SKILL.md`, `example.md`, `example.html`, and `assets/`.

Not run:

- `pnpm -F @html-anything/next typecheck`
- `pnpm -F @html-anything/next test`

Reason: `pnpm` is not available in my local PATH.