### PR TITLE
add IBM Bob agent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ On startup we scan `PATH` (including `~/.local/bin`, `~/.bun/bin`, `/opt/homebre
 | **OpenCode** | `opencode-cli` / `opencode` | `opencode run --format json --dangerously-skip-permissions -` |
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
-| **IBM Bob** | `bob` | `bob --output-format stream-json` |
+| **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
 
 > The detection strategy and per-CLI adapter shape are borrowed directly from [`nexu-io/open-design`](https://github.com/nexu-io/open-design) and [`multica-ai/multica`](https://github.com/multica-ai/multica): one privileged process spawns CLIs, JSON-line is the wire protocol, every CLI gets a thin adapter in [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center"><b>Live page:</b> <a href="https://open-design.ai/html-anything/"><b>open-design.ai/html-anything/</b></a> — overview, surface modes, and showcase before you clone.</p>
 
-> **Markdown is the draft. HTML is what humans read. Your local agent writes it.** The agentic HTML editor — in the agentic era, you don't hand-edit docs anymore, so the output format should be what the reader actually wants: HTML. Local-first, zero API key, reuses the CLI session you already have logged in — **8 coding-agent CLIs** auto-detected on your `PATH` (Claude Code · Cursor Agent · Codex · Gemini CLI · GitHub Copilot CLI · OpenCode · Qwen Coder · Aider), driven by **75 composable skill templates** across **9 deliverable surfaces** (magazine articles · keynote decks · résumés · posters · Xiaohongshu cards · tweet cards · web prototypes · data reports · Hyperframes videos). One-click export to WeChat / X / Zhihu, or download `.html` / `.png`.
+> **Markdown is the draft. HTML is what humans read. Your local agent writes it.** The agentic HTML editor — in the agentic era, you don't hand-edit docs anymore, so the output format should be what the reader actually wants: HTML. Local-first, zero API key, reuses the CLI session you already have logged in — **9 coding-agent CLIs** auto-detected on your `PATH` (Claude Code · Cursor Agent · Codex · Gemini CLI · GitHub Copilot CLI · OpenCode · Qwen Coder · Aider · IBM Bob), driven by **75 composable skill templates** across **9 deliverable surfaces** (magazine articles · keynote decks · résumés · posters · Xiaohongshu cards · tweet cards · web prototypes · data reports · Hyperframes videos). One-click export to WeChat / X / Zhihu, or download `.html` / `.png`.
 
 <p align="center">
   <img src="docs/assets/banner.png" alt="HTML Anything — the agentic HTML editor, on your laptop" width="100%" />
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
-  <a href="#supported-coding-agents"><img alt="Agents" src="https://img.shields.io/badge/agents-8%20CLIs-black?style=flat-square" /></a>
+  <a href="#supported-coding-agents"><img alt="Agents" src="https://img.shields.io/badge/agents-9%20CLIs-black?style=flat-square" /></a>
   <a href="#skills"><img alt="Skills" src="https://img.shields.io/badge/skills-75-orange?style=flat-square" /></a>
   <a href="#export-targets"><img alt="Export" src="https://img.shields.io/badge/export-WeChat%20%C2%B7%20X%20%C2%B7%20Zhihu%20%C2%B7%20PNG-9b59b6?style=flat-square" /></a>
   <a href="#quickstart"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-30%20seconds-green?style=flat-square" /></a>
@@ -202,6 +202,7 @@ On startup we scan `PATH` (including `~/.local/bin`, `~/.bun/bin`, `/opt/homebre
 | **OpenCode** | `opencode-cli` / `opencode` | `opencode run --format json --dangerously-skip-permissions -` |
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
+| **IBM Bob** | `bob` | `bob --output-format stream-json` |
 
 > The detection strategy and per-CLI adapter shape are borrowed directly from [`nexu-io/open-design`](https://github.com/nexu-io/open-design) and [`multica-ai/multica`](https://github.com/multica-ai/multica): one privileged process spawns CLIs, JSON-line is the wire protocol, every CLI gets a thin adapter in [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,7 +202,7 @@ pnpm -F @html-anything/e2e test
 | **OpenCode** | `opencode-cli` / `opencode` | `opencode run --format json --dangerously-skip-permissions -` |
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
-| **IBM Bob** | `bob` | `bob --output-format stream-json` |
+| **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
 
 > 这一层的设计直接借鉴了 [`nexu-io/open-design`](https://github.com/nexu-io/open-design) 和 [`multica-ai/multica`](https://github.com/multica-ai/multica) 的 agent 检测策略：唯一被 spawn 子进程的进程是 server route，业务进程不直接 spawn；CLI 的 stdin / stdout 用 JSON-line 协议复用，每个 CLI 一个轻 adapter，统一在 [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 <p align="center"><b>项目主页:</b> <a href="https://open-design.ai/html-anything/"><b>open-design.ai/html-anything/</b></a> —— 不用 clone 也能先看看 HTML Anything 长什么样、能干啥。</p>
 
-> **Markdown 是草稿, HTML 才是给人读的成品 —— 让本地 agent 直接写 HTML。** Agent 时代的 HTML 编辑器 —— 既然你已经不亲手改文档、全都让 Claude 改了, 那 agent 的输出就该是读者真正想看的 HTML, 而不是中间态的 markdown。本地优先、零 API Key、复用你已经登录好的 CLI session —— **8 个 coding-agent CLI** 在 `PATH` 上自动识别（Claude Code · Cursor Agent · Codex · Gemini CLI · GitHub Copilot CLI · OpenCode · Qwen Coder · Aider），驱动 **75 套 skill 模板** 和 **9 类可交付场景**（杂志文章 · Keynote PPT · 简历 · 海报 · 小红书 · 推特卡 · Web 原型 · 数据报告 · Hyperframes 视频）。一键复制到公众号 / 推特 / 知乎，或者下载 `.html` / `.png`。
+> **Markdown 是草稿, HTML 才是给人读的成品 —— 让本地 agent 直接写 HTML。** Agent 时代的 HTML 编辑器 —— 既然你已经不亲手改文档、全都让 Claude 改了, 那 agent 的输出就该是读者真正想看的 HTML, 而不是中间态的 markdown。本地优先、零 API Key、复用你已经登录好的 CLI session —— **9 个 coding-agent CLI** 在 `PATH` 上自动识别（Claude Code · Cursor Agent · Codex · Gemini CLI · GitHub Copilot CLI · OpenCode · Qwen Coder · Aider · IBM Bob），驱动 **75 套 skill 模板** 和 **9 类可交付场景**（杂志文章 · Keynote PPT · 简历 · 海报 · 小红书 · 推特卡 · Web 原型 · 数据报告 · Hyperframes 视频）。一键复制到公众号 / 推特 / 知乎，或者下载 `.html` / `.png`。
 
 <p align="center">
   <img src="docs/assets/banner.png" alt="HTML Anything — agent 时代的 HTML 编辑器，在你的笔记本上" width="100%" />
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
-  <a href="#-自动识别本地-agent"><img alt="Agents" src="https://img.shields.io/badge/agents-8%20CLIs-black?style=flat-square" /></a>
+  <a href="#-自动识别本地-agent"><img alt="Agents" src="https://img.shields.io/badge/agents-9%20CLIs-black?style=flat-square" /></a>
   <a href="#-skills"><img alt="Skills" src="https://img.shields.io/badge/skills-75-orange?style=flat-square" /></a>
   <a href="#一键发布到平台"><img alt="Export" src="https://img.shields.io/badge/export-WeChat%20%C2%B7%20X%20%C2%B7%20Zhihu%20%C2%B7%20PNG-9b59b6?style=flat-square" /></a>
   <a href="#-30-秒上手"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-30%20seconds-green?style=flat-square" /></a>
@@ -202,6 +202,7 @@ pnpm -F @html-anything/e2e test
 | **OpenCode** | `opencode-cli` / `opencode` | `opencode run --format json --dangerously-skip-permissions -` |
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
+| **IBM Bob** | `bob` | `bob --output-format stream-json` |
 
 > 这一层的设计直接借鉴了 [`nexu-io/open-design`](https://github.com/nexu-io/open-design) 和 [`multica-ai/multica`](https://github.com/multica-ai/multica) 的 agent 检测策略：唯一被 spawn 子进程的进程是 server route，业务进程不直接 spawn；CLI 的 stdin / stdout 用 JSON-line 协议复用，每个 CLI 一个轻 adapter，统一在 [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts)。
 

--- a/next/src/lib/agents/__tests__/argv.test.ts
+++ b/next/src/lib/agents/__tests__/argv.test.ts
@@ -162,3 +162,60 @@ describe("parseLine opencode", () => {
     ]);
   });
 });
+
+describe("parseLine bob", () => {
+  it("extracts text from stream-json output", () => {
+    const line = JSON.stringify({
+      text: "<html><body>Hello</body></html>",
+    });
+
+    expect(parseLine("bob", line)).toEqual([
+      {
+        kind: "delta",
+        text: "<html><body>Hello</body></html>",
+      },
+    ]);
+  });
+
+  it("extracts content field when present", () => {
+    const line = JSON.stringify({
+      content: "<html><body>World</body></html>",
+    });
+
+    expect(parseLine("bob", line)).toEqual([
+      {
+        kind: "delta",
+        text: "<html><body>World</body></html>",
+      },
+    ]);
+  });
+
+  it("extracts message field when present", () => {
+    const line = JSON.stringify({
+      message: "<html><body>Test</body></html>",
+    });
+
+    expect(parseLine("bob", line)).toEqual([
+      {
+        kind: "delta",
+        text: "<html><body>Test</body></html>",
+      },
+    ]);
+  });
+
+  it("handles final answer after thinking when --hide-intermediary-output is used", () => {
+    // When --hide-intermediary-output is enabled, Bob only emits the final answer.
+    // This test verifies that the parser correctly handles the final completion.
+    const finalAnswer = JSON.stringify({
+      text: "<html><body>Final result</body></html>",
+    });
+
+    expect(parseLine("bob", finalAnswer)).toEqual([
+      {
+        kind: "delta",
+        text: "<html><body>Final result</body></html>",
+      },
+    ]);
+  });
+});
+

--- a/next/src/lib/agents/argv.ts
+++ b/next/src/lib/agents/argv.ts
@@ -83,6 +83,10 @@ export function buildArgv(agent: string, _opts: AgentArgvOpts = {}): string[] {
         "json",
         ...(model ? ["--model", model] : []),
       ];
+    case "bob":
+      // Bob's `-p`/`--prompt` flag expects an argument; we stream the prompt via
+      // stdin, so omit `-p` and just request stream-json output.
+      return ["--output-format", "stream-json"];
     case "opencode":
       return [
         "run",
@@ -410,6 +414,12 @@ function parseLineWithState(agent: string, line: string, state: ParseState): Age
   }
 
   if (agent === "qwen") {
+    if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
+    if (typeof obj.content === "string") out.push({ kind: "delta", text: obj.content });
+    if (typeof obj.message === "string") out.push({ kind: "delta", text: obj.message });
+  }
+
+  if (agent === "bob") {
     if (typeof obj.text === "string") out.push({ kind: "delta", text: obj.text });
     if (typeof obj.content === "string") out.push({ kind: "delta", text: obj.content });
     if (typeof obj.message === "string") out.push({ kind: "delta", text: obj.message });

--- a/next/src/lib/agents/argv.ts
+++ b/next/src/lib/agents/argv.ts
@@ -86,7 +86,9 @@ export function buildArgv(agent: string, _opts: AgentArgvOpts = {}): string[] {
     case "bob":
       // Bob's `-p`/`--prompt` flag expects an argument; we stream the prompt via
       // stdin, so omit `-p` and just request stream-json output.
-      return ["--output-format", "stream-json"];
+      // --hide-intermediary-output suppresses thinking/reasoning, leaving only
+      // the final completion in stdout.
+      return ["--output-format", "stream-json", "--hide-intermediary-output"];
     case "opencode":
       return [
         "run",

--- a/next/src/lib/agents/detect.ts
+++ b/next/src/lib/agents/detect.ts
@@ -140,6 +140,14 @@ export const AGENTS: AgentDef[] = [
     ],
   },
   {
+    id: "bob",
+    label: "IBM Bob Shell",
+    bin: "bob",
+    envOverride: "BOB_BIN",
+    vendor: "IBM",
+    fallbackModels: [DEFAULT_MODEL],
+  },
+  {
     id: "opencode",
     label: "OpenCode",
     bin: "opencode-cli",

--- a/next/src/lib/agents/invoke.ts
+++ b/next/src/lib/agents/invoke.ts
@@ -213,6 +213,12 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           stdoutBuf = stdoutBuf.slice(nl + 1);
           if (!line) continue;
           for (const part of parse(line)) {
+            // Some agents (bob) may echo the entire prompt back as the first
+            // streamed delta. Suppress that to avoid polluting the user-facing
+            // output with the system prompt.
+            if (opts.agent === "bob" && part.kind === "delta") {
+              if (part.text.trim() === opts.prompt.trim()) continue;
+            }
             if (part.kind === "delta") safeEnqueue({ type: "delta", text: part.text });
             else if (part.kind === "html") safeEnqueue({ type: "html", text: part.text });
             else if (part.kind === "meta") safeEnqueue({ type: "meta", key: part.key, value: part.value });


### PR DESCRIPTION
## Summary

Add support for IBM Bob Shell CLI as a new coding agent adapter.

## Changes

- **`next/src/lib/agents/detect.ts`**: Add bob agent definition with IBM vendor info and fallback models
- **`next/src/lib/agents/argv.ts`**: 
  - Add bob case in `buildArgv()` to use `--output-format stream-json`
  - Add bob parsing logic in `parseLineWithState()` to handle text/content/message fields
- **`next/src/lib/agents/invoke.ts`**: Add prompt echo suppression to avoid duplicating system prompts in output
- **`README.md`**: Update agent count badge (8 → 9 CLIs) and add IBM Bob to supported agents table
- **`README.zh-CN.md`**: Update Chinese README with same changes

## Testing

- ✅ Bob CLI is installed and available at `/opt/homebrew/bin/bob`
- ✅ Verified bob supports `--output-format stream-json` flag
- ✅ Integration follows the same pattern as existing agents (qwen, opencode)

## Implementation Details

Bob is invoked via stdin with `stream-json` output format, similar to other agents. The adapter reuses the existing JSON-line parser infrastructure and handles three common output fields: `text`, `content`, and `message`.

The implementation includes a workaround in `invoke.ts` to suppress prompt echo that bob may send back as the first streamed delta, preventing system prompt pollution in user-facing output.

## Checklist

- [x] Agent adapter added to `detect.ts`
- [x] Command-line arguments configured in `buildArgv()`
- [x] Stream parser added in `parseLineWithState()`
- [x] README.md updated with agent entry
- [x] README.zh-CN.md updated with agent entry
- [x] Changes follow existing agent adapter patterns
- [x] No new dependencies added

## References

- IBM Bob Shell: https://www.ibm.com/products/watsonx-code-assistant/bob
- Follows contribution guidelines from [CONTRIBUTING.md](https://github.com/nexu-io/html-anything/blob/main/CONTRIBUTING.md#adding-a-new-coding-agent-cli)