### PR TITLE
feat: restore i18n localization with English default

### DIFF
--- a/next/src/app/api/convert/route.ts
+++ b/next/src/app/api/convert/route.ts
@@ -35,28 +35,28 @@ function buildEditPrompt(args: {
   oldHtml: string;
   format: string;
 }): string {
-  return `你正在执行一次**最小化差异编辑** (diff-edit), 不是从 0 重新生成。
+  return `You are performing a **minimal diff-edit**, not regenerating from scratch.
 
-模板风格: ${args.templateName} (${args.templateAspect})
-输入格式: ${args.format}
+Template style: ${args.templateName} (${args.templateAspect})
+Input format: ${args.format}
 
-【硬性规则】
-1. 仅输出完整的、修改后的 HTML。第一个字符必须是 \`<\`, 最后必须是 \`</html>\`。
-2. **不要**用 markdown 围栏包裹, 不要任何解释性文字。
-3. **禁止使用 Write / Edit / MultiEdit / Bash 等文件工具** — HTML 必须直接在助手回复正文里流式输出, 不要存到 \`.html\` 文件再回复"已输出至 …"。
-4. 保留原 HTML 的 \`<head>\` (CDN / 字体 / 样式 / meta), 保留所有不需要变化的 DOM 结构 — 字体、配色、布局、栅格、组件结构、动画都不许改。
-5. 仅根据 "旧内容 vs 新内容" 的差异, 替换或调整对应的文字 / 数据节点。
-6. 如果新内容增加了条目, 沿用原有的卡片 / 行 / slide / 章节结构添加; 如果删除了条目, 移除对应的元素。
-7. 如果新旧内容只差几个字, 也只改那几个字 — 不要顺手 "优化" 或 "重排"。
-8. 不要捏造数据。新内容里没有的就不要写。
+[Hard Rules]
+1. Output only the complete, modified HTML. The first character must be \`<\`, the last must be \`</html>\`.
+2. **Do NOT** wrap in markdown fences, no explanatory text.
+3. **Do NOT use Write / Edit / MultiEdit / Bash or any file tools** — the HTML must be streamed directly in the assistant reply body; do not save to an \`.html\` file.
+4. Preserve the original HTML's \`<head>\` (CDN / fonts / styles / meta), preserve all DOM structure that does not need changes — fonts, palette, layout, grid, component structure, and animations must not be altered.
+5. Only replace or adjust the text / data nodes that differ between "old content vs new content".
+6. If new content adds items, follow the existing card / row / slide / section structure to add them; if items are removed, remove the corresponding elements.
+7. If old and new content differ by only a few characters, change only those characters — do not "optimize" or "rearrange" anything else.
+8. Do not fabricate data. If it is not in the new content, do not write it.
 
-【旧内容】
+[Old Content]
 ${args.oldContent}
 
-【新内容】
+[New Content]
 ${args.newContent}
 
-【已有 HTML — 请基于此修改, 输出完整的修改后版本】
+[Existing HTML — modify this and output the complete modified version]
 ${args.oldHtml}
 `;
 }

--- a/next/src/app/api/draft/route.ts
+++ b/next/src/app/api/draft/route.ts
@@ -18,20 +18,20 @@ type Body = {
 
 function buildDraftPrompt(args: { instruction: string; context: string }): string {
   const ctx = args.context.trim();
-  return `你正在为用户起草一段 **markdown** 内容（不是 HTML，不是 JSON，不是代码）。
+  return `You are drafting **markdown** content for the user (not HTML, not JSON, not code).
 
-【硬性规则】
-1. 只输出 markdown 正文，不要任何前后解释、不要 \`\`\`md 围栏、不要"以下是…"开头。
-2. 第一个字符就是正文。最后一个字符是正文末尾。
-3. 不要捏造数据、不要凭空添加引用链接。
-4. 标题、列表、强调、引用、代码块按 markdown 语法书写。
-5. 如果用户没有指定语言，使用与"已有内容"一致的语言；都没有就用中文。
-6. 长度控制：除非用户明确要求长文，控制在 300 字以内。
+[Hard Rules]
+1. Output only the markdown body — no preamble, no \`\`\`md fences, no "Here is…" opening.
+2. The first character is the body text. The last character is the end of the body.
+3. Do not fabricate data or invent reference links.
+4. Use proper markdown syntax for headings, lists, emphasis, blockquotes, and code blocks.
+5. If the user does not specify a language, match the language of the "existing content"; if both are empty, use English.
+6. Length: unless the user explicitly requests a long piece, keep it under 300 words.
 
-【用户当前编辑器里的内容（可能为空）】
-${ctx ? ctx : "（空）"}
+[Current content in the user's editor (may be empty)]
+${ctx ? ctx : "(empty)"}
 
-【用户的需求】
+[User's request]
 ${args.instruction}
 `;
 }

--- a/next/src/lib/i18n.ts
+++ b/next/src/lib/i18n.ts
@@ -373,6 +373,27 @@ export interface Dict {
   "template.scenario.education": string;
   "template.scenario.creator": string;
   "template.scenario.video": string;
+
+  // Utility / non-component strings
+  "time.justNow": string;
+  "time.secsAgo": string;
+  "time.minsAgo": string;
+  "time.hoursAgo": string;
+  "log.diffEditPrefix": string;
+  "log.preparing": string;
+  "log.inputSize": string;
+  "log.model": string;
+  "log.template": string;
+  "log.originalHtml": string;
+  "log.rawContentSeparator": string;
+  "parse.rowsCols": string;
+  "parse.fields": string;
+  "parse.firstNRows": string;
+  "parse.failed": string;
+  "parse.jsonTruncated": string;
+  "parse.jsonFailed": string;
+  "draft.needAgent": string;
+  "loader.exampleSuffix": string;
 }
 
 const en: Dict = {
@@ -735,6 +756,27 @@ const en: Dict = {
   "template.scenario.education": "Education",
   "template.scenario.creator": "Creator",
   "template.scenario.video": "Video",
+
+  // Utility / non-component strings
+  "time.justNow": "just now",
+  "time.secsAgo": "{n}s ago",
+  "time.minsAgo": "{n}m ago",
+  "time.hoursAgo": "{n}h ago",
+  "log.diffEditPrefix": "🔁 diff-edit mode",
+  "log.preparing": "Preparing {agent} · template {template} · {size}",
+  "log.inputSize": "input {n} chars ({fmt})",
+  "log.model": "model {model}",
+  "log.template": "template {template}",
+  "log.originalHtml": "original HTML {size} KB",
+  "log.rawContentSeparator": "--- Raw Content ---",
+  "parse.rowsCols": "[{fmt}] {rows} rows × {cols} columns",
+  "parse.fields": "Fields: {fields}",
+  "parse.firstNRows": "First {n} rows (JSON):",
+  "parse.failed": "[{fmt}] (parse failed: {err})",
+  "parse.jsonTruncated": "[JSON] truncated preview (full {n} bytes):",
+  "parse.jsonFailed": "[JSON parse failed]",
+  "draft.needAgent": "Select an agent first (top-right corner)",
+  "loader.exampleSuffix": "Example",
 };
 
 const zhCN: Dict = {
@@ -1093,6 +1135,27 @@ const zhCN: Dict = {
   "template.scenario.education": "教育 / 学习",
   "template.scenario.creator": "创作者",
   "template.scenario.video": "视频",
+
+  // Utility / non-component strings
+  "time.justNow": "刚刚",
+  "time.secsAgo": "{n} 秒前",
+  "time.minsAgo": "{n} 分钟前",
+  "time.hoursAgo": "{n} 小时前",
+  "log.diffEditPrefix": "🔁 diff-edit 模式",
+  "log.preparing": "准备调用 {agent} · 模板 {template} · {size}",
+  "log.inputSize": "输入 {n} 字符 ({fmt})",
+  "log.model": "模型 {model}",
+  "log.template": "模板 {template}",
+  "log.originalHtml": "原 HTML {size} KB",
+  "log.rawContentSeparator": "--- 原始内容 ---",
+  "parse.rowsCols": "[{fmt}] {rows} 行 × {cols} 列",
+  "parse.fields": "字段: {fields}",
+  "parse.firstNRows": "前 {n} 行 (JSON):",
+  "parse.failed": "[{fmt}] (解析失败: {err})",
+  "parse.jsonTruncated": "[JSON] 截断预览 (完整 {n} 字节):",
+  "parse.jsonFailed": "[JSON 但解析失败]",
+  "draft.needAgent": "先在右上角选择一个 agent",
+  "loader.exampleSuffix": "示例",
 };
 
 const DICTS: Record<Locale, Dict> = {

--- a/next/src/lib/parsers/auto.ts
+++ b/next/src/lib/parsers/auto.ts
@@ -96,13 +96,13 @@ export function summarizeForAgent(input: string): ParsedSummary {
         structured = { fields, rows };
         const sampleRows = rows.slice(0, 20);
         preview = [
-          `[${format.toUpperCase()}] ${rows.length} 行 × ${fields.length} 列`,
-          `字段: ${fields.join(", ")}`,
-          `前 ${sampleRows.length} 行 (JSON):`,
+          `[${format.toUpperCase()}] ${rows.length} rows × ${fields.length} columns`,
+          `Fields: ${fields.join(", ")}`,
+          `First ${sampleRows.length} rows (JSON):`,
           JSON.stringify(sampleRows, null, 2),
         ].join("\n");
       } catch (err) {
-        preview = `[${format}] (解析失败: ${err instanceof Error ? err.message : err})`;
+        preview = `[${format}] (parse failed: ${err instanceof Error ? err.message : err})`;
       }
       break;
     }
@@ -113,27 +113,27 @@ export function summarizeForAgent(input: string): ParsedSummary {
         const pretty = JSON.stringify(parsed, null, 2);
         preview =
           pretty.length > 4000
-            ? `[JSON] 截断预览 (完整 ${pretty.length} 字节):\n${pretty.slice(0, 4000)}\n…`
+            ? `[JSON] truncated preview (full ${pretty.length} bytes):\n${pretty.slice(0, 4000)}\n…`
             : `[JSON]\n${pretty}`;
       } catch (err) {
-        preview = `[JSON 但解析失败]\n${input.slice(0, 1000)}`;
+        preview = `[JSON parse failed]\n${input.slice(0, 1000)}`;
       }
       break;
     }
     case "markdown":
-      preview = `[Markdown 文档, ${input.length} 字符]`;
+      preview = `[Markdown document, ${input.length} chars]`;
       break;
     case "html":
-      preview = `[HTML 文档, ${input.length} 字符]`;
+      preview = `[HTML document, ${input.length} chars]`;
       break;
     case "sql":
-      preview = `[SQL 查询/脚本]`;
+      preview = `[SQL query/script]`;
       break;
     case "yaml":
-      preview = `[YAML 配置]`;
+      preview = `[YAML config]`;
       break;
     default:
-      preview = `[纯文本, ${input.length} 字符]`;
+      preview = `[Plain text, ${input.length} chars]`;
   }
 
   // Truncate raw for agent if huge
@@ -141,7 +141,7 @@ export function summarizeForAgent(input: string): ParsedSummary {
   if (raw.length > MAX_RAW_FOR_AGENT) {
     agentRaw =
       raw.slice(0, MAX_RAW_FOR_AGENT) +
-      `\n\n[...内容过长, 已截断 (${raw.length - MAX_RAW_FOR_AGENT} 字符省略)]`;
+      `\n\n[...content too long, truncated (${raw.length - MAX_RAW_FOR_AGENT} chars omitted)]`;
   }
 
   return { format, raw: agentRaw, preview, structured };

--- a/next/src/lib/store.ts
+++ b/next/src/lib/store.ts
@@ -122,7 +122,7 @@ function makeTask(init?: Partial<Task>): Task {
   const now = Date.now();
   return {
     id: init?.id ?? `t_${now.toString(36)}_${Math.random().toString(36).slice(2, 7)}`,
-    name: init?.name ?? "新任务",
+    name: init?.name ?? "New Task",
     content: init?.content ?? "",
     format: init?.format ?? "text",
     filename: init?.filename,
@@ -141,7 +141,7 @@ function makeTask(init?: Partial<Task>): Task {
 
 // Shipped locales. Adding a new one means dropping a dictionary into
 // `src/lib/i18n/locales/` and registering it in `src/lib/i18n.ts`.
-// We ship only en + zh-CN today and leave the rest to contributors.
+// We ship en + zh-CN today and leave the rest to contributors.
 export type Locale = "en" | "zh-CN";
 
 export const LOCALES: Locale[] = ["en", "zh-CN"];
@@ -277,7 +277,7 @@ function patchTask(tasks: Task[], id: string, patch: Partial<Task> | ((t: Task) 
   return changed ? next : tasks;
 }
 
-const initialTask = makeTask({ name: "任务 1" });
+const initialTask = makeTask({ name: "Task 1" });
 
 export const useStore = create<State>()(
   persist(
@@ -297,7 +297,7 @@ export const useStore = create<State>()(
       newTask: (init) => {
         const tasks = get().tasks;
         const n = tasks.length + 1;
-        const t = makeTask({ name: init?.name ?? `任务 ${n}`, ...init });
+        const t = makeTask({ name: init?.name ?? `Task ${n}`, ...init });
         set({ tasks: [...tasks, t], activeTaskId: t.id });
         return t.id;
       },
@@ -305,7 +305,7 @@ export const useStore = create<State>()(
         const { tasks, activeTaskId } = get();
         if (tasks.length <= 1) {
           // never leave 0 tasks — replace with a fresh empty one
-          const fresh = makeTask({ name: "任务 1" });
+          const fresh = makeTask({ name: "Task 1" });
           set({ tasks: [fresh], activeTaskId: fresh.id });
           void deleteTaskRuns(id).catch(() => {});
           return;
@@ -512,7 +512,7 @@ export const useStore = create<State>()(
         if (fromVersion < 2 && persisted && typeof persisted === "object") {
           const old = persisted as Record<string, unknown>;
           const t = makeTask({
-            name: "任务 1",
+            name: "Task 1",
             content: typeof old.content === "string" ? old.content : "",
             format: typeof old.format === "string" ? old.format : "text",
             filename: typeof old.filename === "string" ? old.filename : undefined,

--- a/next/src/lib/templates/loader.ts
+++ b/next/src/lib/templates/loader.ts
@@ -174,7 +174,7 @@ function fmToMeta(id: string, fm: SkillFrontmatter, hasHtml: boolean, hasMd: boo
   if (fm.example_id || hasMd || hasHtml) {
     meta.example = {
       id: fm.example_id ?? `example-${id}`,
-      name: fm.example_name ?? `${meta.zhName} 示例`,
+      name: fm.example_name ?? `${meta.enName} Example`,
       format: fm.example_format ?? "markdown",
       tagline: fm.example_tagline ?? "",
       desc: fm.example_desc ?? "",

--- a/next/src/lib/templates/shared.ts
+++ b/next/src/lib/templates/shared.ts
@@ -4,36 +4,36 @@
  * without depending on the disk loader's full surface.
  */
 export const SHARED_DESIGN_DIRECTIVES = `
-你是世界级的视觉设计师 + 资深前端工程师。请输出一份**自包含的单文件 HTML**，要求：
+You are a world-class visual designer + senior front-end engineer. Output a **self-contained single-file HTML** with these requirements:
 
-【内容驱动数量 — 最高优先级, 覆盖模板里的任何数字】
-- 模板只定义"可用版面 / 风格 / 配色 / 字体 / 组件库", **不定义** slide / 帧 / 卡片 / section 的数量。
-- 输出的 slide / frame / card / section 数量**完全由【用户内容】的实际长度和信息结构决定**。必须**完整覆盖**用户内容的每一个要点、章节、数据组, **不许总结、压缩、丢弃信息**。
-- 如果模板正文里写了类似"挑 6-10 张组成 deck / 输出 6-10 帧 / 3-6 张卡片"的数字, **一律视为短示例下的参考下限, 不是上限**。短内容可以低于该范围, 长内容应远超该范围 — 用户给了 12k 字符的内容, 输出 4-6 张是**严重错误**。
-- 模板里的"22 个锁死版面 / 10 个磁带式版面 / N 个 layout"指的是**可复用的版式池**, 同一个版式允许在不同内容上多次出现 (例如 KPI Tower 可以连续用 3 次承载不同章节的数据), 不是页数上限。
-- 推荐做法: 先把【用户内容】按语义切成若干段 (章节标题 / 论点 / 数据组 / 列表项 / 步骤), 每一段 → 至少一个独立的 slide / section / card, 然后再从模板的版式池里给每一段挑最合适的版面。宁可多页也不要把多个独立要点硬塞进一页。
+[Content-Driven Quantity — Highest Priority, Overrides Any Number in the Template]
+- The template only defines "available layouts / styles / palettes / fonts / component library", it does **NOT** define the number of slides / frames / cards / sections.
+- The number of slides / frames / cards / sections is **entirely determined by the user content's** actual length and information structure. You must **fully cover** every point, chapter, data group in the user content — **no summarizing, compressing, or discarding information**.
+- If the template body mentions numbers like "pick 6-10 slides / output 6-10 frames / 3-6 cards", **treat them as reference lower bounds for short examples, not upper limits**. Short content may go below that range; long content should far exceed it — if the user provides 12k characters of content, outputting 4-6 slides is a **critical error**.
+- Template phrases like "22 locked layouts / 10 tape-style layouts / N layouts" refer to a **reusable layout pool** — the same layout may appear multiple times for different content (e.g., KPI Tower can be used 3 times for different chapter data); it is not a page count limit.
+- Recommended approach: first segment the user content semantically (chapter titles / arguments / data groups / list items / steps), each segment → at least one independent slide / section / card, then pick the most suitable layout from the template's layout pool for each segment. Prefer more pages over cramming multiple independent points into one.
 
-【硬性技术要求】
-- **禁止使用 Write / Edit / MultiEdit / Bash / Create / 任何文件系统工具**。不要把 HTML 写到任何 \`.html\` 文件里。前端直接捕获你的 stdout 文本, 文件落盘由前端负责。
-- 直接把完整的 HTML 文档作为助手回复的正文流式输出。不要先说"我来生成"、"已输出至 …"之类的话。
-- 文档以 \`<!DOCTYPE html>\` 开头, 末尾以 \`</html>\` 结束。
-- 在 \`<head>\` 中通过 CDN 引入 Tailwind v3 Play (https://cdn.tailwindcss.com) 与所需的 Google Fonts。
-- 不要引用任何外部图片 URL（除非你能保证 URL 长期有效；优先使用 CSS / SVG 内联绘制）。
-- 必要的脚本（图表、动画）通过 jsdelivr CDN 引入；保持单文件可双击打开即用。
-- 输出**纯 HTML**, 不要用 markdown 代码围栏包裹, 不要任何解释性文字。第一个字符必须是 \`<\`。
+[Hard Technical Requirements]
+- **Do NOT use Write / Edit / MultiEdit / Bash / Create / any file-system tool**. Do not write HTML to any \`.html\` file. The frontend captures your stdout text directly; file persistence is the frontend's job.
+- Stream the complete HTML document directly as the assistant reply body. Do not say "I'll generate" or "Saved to …" or similar preamble.
+- The document starts with \`<!DOCTYPE html>\` and ends with \`</html>\`.
+- Include Tailwind v3 Play CDN (https://cdn.tailwindcss.com) and required Google Fonts in \`<head>\`.
+- Do not reference any external image URLs (unless you can guarantee long-term availability; prefer CSS / inline SVG).
+- Required scripts (charts, animations) via jsdelivr CDN; keep the single file openable by double-click.
+- Output **pure HTML** — no markdown code fences, no explanatory text. The first character must be \`<\`.
 
-【设计准则 — 世界级标准】
-- 排版: 中文优先 \`Noto Sans SC\` / \`Noto Serif SC\`, 英文 \`Inter\` / \`Manrope\` / \`SF Pro\` 风格。
-- 色彩: 使用 1 个主色 + 2 个中性色 + 至多 1 个强调色; 大胆留白; 不使用纯黑纯白 (#000/#fff), 改用 \`#0a0a0a\` / \`#fafafa\`。
-- 网格: 8 px 基线; 段落最大宽度 65 ch; 标题与正文有清晰的层级。
-- 微观细节: 圆角统一 (rounded-xl/2xl), 投影柔和 (shadow-sm/lg), 边框 1px \`#e5e7eb\` / \`#262626\`。
-- 动效: 仅在必要处使用 \`transition-all\` 或入场 fade-in; 不要喧宾夺主。
-- 无障碍: 颜色对比度 ≥ 4.5; 重要交互有 focus 态。
+[Design Guidelines — World-Class Standards]
+- Typography: \`Inter\` / \`Manrope\` / \`SF Pro\` for Latin; \`Noto Sans SC\` / \`Noto Serif SC\` for CJK if needed.
+- Color: 1 primary + 2 neutrals + at most 1 accent; generous whitespace; avoid pure black/white (#000/#fff) — use \`#0a0a0a\` / \`#fafafa\` instead.
+- Grid: 8 px baseline; max paragraph width 65 ch; clear hierarchy between headings and body.
+- Micro details: consistent border-radius (rounded-xl/2xl), soft shadows (shadow-sm/lg), borders 1px \`#e5e7eb\` / \`#262626\`.
+- Motion: use \`transition-all\` or entrance fade-in only where necessary; never let animation overshadow content.
+- Accessibility: color contrast ≥ 4.5; all interactive elements must have a :focus state.
 
-【内容真实性】
-- **必须使用用户提供的真实数据**, 不要编造、不要 lorem ipsum、不要 "Your text here"。
-- 如果用户数据是结构化数据 (CSV/JSON), 请提取关键洞察并以图表/表格呈现。
-- 中文与英文混排时, 中英文之间留半角空格 (盘古之白)。
+[Content Authenticity]
+- **You must use the user's real data** — no fabrication, no lorem ipsum, no "Your text here".
+- If user data is structured (CSV/JSON), extract key insights and present them as charts/tables.
+- Respond in the same language as the user's content unless otherwise specified.
 
 `;
 
@@ -51,8 +51,8 @@ export function assemblePrompt(opts: {
   return `${SHARED_DESIGN_DIRECTIVES}
 ${opts.body.trim()}
 
-【输入格式】: ${opts.format}
-【用户内容】:
+[Input Format]: ${opts.format}
+[User Content]:
 ${opts.content}
 `;
 }

--- a/next/src/lib/use-autosave.ts
+++ b/next/src/lib/use-autosave.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useStore, selectActiveTask } from "./store";
 import { snapshotDraft } from "./drafts";
+import { t } from "./i18n";
 
 /**
  * Watches editor content and reports save status.
@@ -57,13 +58,14 @@ export function useAutosave() {
   return { status, savedAt };
 }
 
-export function relativeTime(ts: number | null): string {
+export function relativeTime(ts: number | null, locale?: Parameters<typeof t>[0]): string {
   if (!ts) return "";
+  const l = locale ?? useStore.getState().locale;
   const diff = Math.max(0, Date.now() - ts) / 1000;
-  if (diff < 5) return "刚刚";
-  if (diff < 60) return `${Math.round(diff)} 秒前`;
-  if (diff < 3600) return `${Math.round(diff / 60)} 分钟前`;
-  if (diff < 86400) return `${Math.round(diff / 3600)} 小时前`;
+  if (diff < 5) return t(l, "time.justNow");
+  if (diff < 60) return t(l, "time.secsAgo", { n: Math.round(diff) });
+  if (diff < 3600) return t(l, "time.minsAgo", { n: Math.round(diff / 60) });
+  if (diff < 86400) return t(l, "time.hoursAgo", { n: Math.round(diff / 3600) });
   return new Date(ts).toLocaleString();
 }
 

--- a/next/src/lib/use-convert.ts
+++ b/next/src/lib/use-convert.ts
@@ -3,6 +3,7 @@
 import { useCallback } from "react";
 import { useStore } from "./store";
 import { summarizeForAgent } from "./parsers/auto";
+import { t } from "./i18n";
 
 type ConvertReq = {
   taskId: string;
@@ -15,7 +16,7 @@ type ConvertReq = {
 };
 
 /** prefix logged when the run is sent in diff-edit mode (vs full regeneration) */
-const DIFF_LOG_PREFIX = "🔁 diff-edit 模式";
+// Uses i18n key "log.diffEditPrefix"
 
 // per-task abort controllers — multiple tasks can stream concurrently
 const controllers = new Map<string, AbortController>();
@@ -56,7 +57,7 @@ export function useConvert() {
       const summary = summarizeForAgent(inlinedContent);
       const enrichedContent =
         summary.preview && summary.format !== "markdown" && summary.format !== "html" && summary.format !== "text"
-          ? `${summary.preview}\n\n--- 原始内容 ---\n${summary.raw}`
+          ? `${summary.preview}\n\n${t(store.locale, "log.rawContentSeparator")}\n${summary.raw}`
           : summary.raw;
 
       const useModel = req.model && req.model !== "default" ? req.model : undefined;
@@ -89,12 +90,13 @@ export function useConvert() {
         ...(editPayload ?? {}),
       };
 
-      const sizeNote = `输入 ${enrichedContent.length.toLocaleString()} 字符 (${summary.format})`;
+      const locale = store.locale;
+      const sizeNote = t(locale, "log.inputSize", { n: enrichedContent.length.toLocaleString(), fmt: summary.format });
       store.pushLogFor(taskId, {
         kind: "info",
         text: isEdit
-          ? `${DIFF_LOG_PREFIX} · ${req.agent}${useModel ? ` · 模型 ${useModel}` : ""} · 模板 ${req.templateId} · ${sizeNote} · 原 HTML ${(task!.baseHtml!.length / 1024).toFixed(1)} KB`
-          : `准备调用 ${req.agent}${useModel ? ` · 模型 ${useModel}` : ""} · 模板 ${req.templateId} · ${sizeNote}`,
+          ? `${t(locale, "log.diffEditPrefix")} · ${req.agent}${useModel ? ` · ${t(locale, "log.model", { model: useModel })}` : ""} · ${t(locale, "log.template", { template: req.templateId })} · ${sizeNote} · ${t(locale, "log.originalHtml", { size: (task!.baseHtml!.length / 1024).toFixed(1) })}`
+          : `${t(locale, "log.preparing", { agent: req.agent, template: req.templateId, size: sizeNote })}${useModel ? ` · ${t(locale, "log.model", { model: useModel })}` : ""}`,
       });
 
       try {

--- a/next/src/lib/use-draft.ts
+++ b/next/src/lib/use-draft.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import { useStore } from "./store";
+import { t } from "./i18n";
 
 type DraftReq = {
   instruction: string;
@@ -37,7 +38,7 @@ export function useDraft() {
     const agent = store.selectedAgent;
     if (!agent) {
       setStatus("error");
-      setError("先在右上角选择一个 agent");
+      setError(t(store.locale, "draft.needAgent"));
       return;
     }
     const taskId = store.activeTaskId;


### PR DESCRIPTION
- Re-register zh-CN dictionary in DICTS, restore Locale type
- Add i18n keys for utility strings (relativeTime, log messages, parser, draft error)
- Use t() in use-autosave, use-convert, use-draft for user-facing strings
- Keep agent prompts (shared.ts, route.ts) in English for LLM quality
- Fix formats-gallery locale check
- Fix loader.ts to use enName for example fallback