### PR TITLE
fix: preserve zero hyperframe durations

### DIFF
--- a/next/src/lib/hyperframes.test.ts
+++ b/next/src/lib/hyperframes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseHyperframes } from "./hyperframes";
+
+describe("parseHyperframes", () => {
+  it("preserves explicit zero durations from data attributes", () => {
+    const parsed = parseHyperframes(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="frame" data-duration="0">
+            <h1>Instant frame</h1>
+          </section>
+        </body>
+      </html>
+    `);
+
+    expect(parsed.frames[0]?.duration).toBe(0);
+  });
+
+  it("preserves explicit zero durations from inline markers", () => {
+    const parsed = parseHyperframes(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="frame">
+            <h1>Instant marker frame</h1>
+            <!-- frame:1 duration:0 transition:cut -->
+          </section>
+        </body>
+      </html>
+    `);
+
+    expect(parsed.frames[0]?.duration).toBe(0);
+  });
+});

--- a/next/src/lib/hyperframes.ts
+++ b/next/src/lib/hyperframes.ts
@@ -78,6 +78,16 @@ function extractAttr(tag: string, name: string): string {
   return pick(re, tag);
 }
 
+function extractOpeningTag(html: string): string {
+  return /<section\b[^>]*>/i.exec(html)?.[0] ?? "";
+}
+
+function parseOptionalDuration(raw: string): number | undefined {
+  if (raw === "") return undefined;
+  const duration = Number(raw);
+  return Number.isFinite(duration) ? duration : undefined;
+}
+
 function parseMeta(html: string): { json: string; entries: HyperframeMetaEntry[] } {
   const raw = pick(META_RE, html).trim();
   if (!raw) return { json: "", entries: [] };
@@ -101,7 +111,7 @@ function parseInlineMarker(innerHtml: string): { duration?: number; transition?:
     innerHtml,
   );
   if (!m) return {};
-  return { duration: Number(m[1]) || undefined, transition: m[2] };
+  return { duration: parseOptionalDuration(m[1]), transition: m[2] };
 }
 
 /**
@@ -136,8 +146,8 @@ export function parseHyperframes(fullHtml: string): HyperframesParsed {
   let idx = 0;
   while ((m = FRAME_RE.exec(fullHtml))) {
     idx += 1;
-    const openTag = pick(/<section\b[^>]*>/i, m[0]);
-    const dataDur = Number(extractAttr(openTag, "data-duration")) || undefined;
+    const openTag = extractOpeningTag(m[0]);
+    const dataDur = parseOptionalDuration(extractAttr(openTag, "data-duration"));
     const dataTransition = extractAttr(openTag, "data-transition") || undefined;
     const inlineStyle = extractAttr(openTag, "style");
     const bg = pick(/background(?:-color)?\s*:\s*([^;"']+)/i, inlineStyle).trim() || undefined;


### PR DESCRIPTION
## Summary
- preserve explicit duration=0 values from Hyperframes data attributes and inline frame markers
- avoid falling back to the 3000ms default for valid zero durations
- add unit coverage for both zero-duration sources

## Tests
- corepack pnpm --dir next exec vitest run src/lib/hyperframes.test.ts
- corepack pnpm --dir next exec tsc --noEmit