### PR TITLE
fix(hyperframes): preserve zero data-duration instead of falling back to default (#110)

### DIFF
--- a/next/src/lib/__tests__/hyperframes.test.ts
+++ b/next/src/lib/__tests__/hyperframes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parseHyperframes } from "../hyperframes";
+
+/** Minimal helper: wraps section(s) in a hyperframes-shaped document. */
+function makeDoc(sections: string): string {
+  return `<!DOCTYPE html><html><head><title>test</title></head><body>${sections}</body></html>`;
+}
+
+describe("parseHyperframes", () => {
+  it("preserves data-duration=0 instead of falling back to default (3000)", () => {
+    const html = makeDoc(
+      '<section class="frame" data-duration="0"><p>instant</p></section>',
+    );
+    const result = parseHyperframes(html);
+    expect(result.isHyperframes).toBe(true);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0].duration).toBe(0);
+  });
+
+  it("treats missing data-duration as undefined → defaults to 3000", () => {
+    const html = makeDoc(
+      '<section class="frame"><p>no duration attr</p></section>',
+    );
+    const result = parseHyperframes(html);
+    expect(result.frames[0].duration).toBe(3000);
+  });
+
+  it("parses a positive data-duration correctly", () => {
+    const html = makeDoc(
+      '<section class="frame" data-duration="5000"><p>slow</p></section>',
+    );
+    const result = parseHyperframes(html);
+    expect(result.frames[0].duration).toBe(5000);
+  });
+
+  it("handles mixed frames: zero, positive, and missing", () => {
+    const html = makeDoc(
+      '<section class="frame" data-duration="0"><p>a</p></section>' +
+        '<section class="frame" data-duration="2000"><p>b</p></section>' +
+        '<section class="frame"><p>c</p></section>',
+    );
+    const result = parseHyperframes(html);
+    expect(result.frames).toHaveLength(3);
+    expect(result.frames[0].duration).toBe(0);
+    expect(result.frames[1].duration).toBe(2000);
+    expect(result.frames[2].duration).toBe(3000);
+  });
+});

--- a/next/src/lib/hyperframes.ts
+++ b/next/src/lib/hyperframes.ts
@@ -136,8 +136,9 @@ export function parseHyperframes(fullHtml: string): HyperframesParsed {
   let idx = 0;
   while ((m = FRAME_RE.exec(fullHtml))) {
     idx += 1;
-    const openTag = pick(/<section\b[^>]*>/i, m[0]);
-    const dataDur = Number(extractAttr(openTag, "data-duration")) || undefined;
+    const openTag = pick(/(<section\b[^>]*>)/i, m[0]);
+    const dataDurStr = extractAttr(openTag, "data-duration");
+    const dataDur = dataDurStr ? Number(dataDurStr) : undefined;
     const dataTransition = extractAttr(openTag, "data-transition") || undefined;
     const inlineStyle = extractAttr(openTag, "style");
     const bg = pick(/background(?:-color)?\s*:\s*([^;"']+)/i, inlineStyle).trim() || undefined;


### PR DESCRIPTION
## Fix: Zero duration incorrectly treated as undefined

Fixes #110

### Problem

In `parseHyperframes()` (`next/src/lib/hyperframes.ts`), the `data-duration` attribute was never correctly read from `<section>` elements due to two bugs:

1. **Missing capture group in openTag regex** — `pick(/<section\b[^>]*>/i, m[0])` used a regex with no capture group, so `pick()` always returned `undefined` (since it returns `m[1]`). This meant `extractAttr()` received `undefined` and could never match any attributes.

2. **Falsy `||` operator** — The original `Number(extractAttr(openTag, "data-duration")) || undefined` treated a duration value of `0` as falsy, replacing it with `undefined` and falling back to the default 3000ms.

### Fix

```diff
- const openTag = pick(/<section\b[^>]*>/i, m[0]);
- const dataDur = Number(extractAttr(openTag, "data-duration")) || undefined;
+ const openTag = pick(/(<section\b[^>]*>)/i, m[0]);
+ const dataDurStr = extractAttr(openTag, "data-duration");
+ const dataDur = dataDurStr ? Number(dataDurStr) : undefined;
```

- Added capture group `(...)` to the openTag regex so `pick()` returns the matched string
- Replaced `|| undefined` with an explicit empty-string check to preserve `0` as a valid duration

### Tests

Added 4 vitest cases in `next/src/lib/__tests__/hyperframes.test.ts`:
- `data-duration="0"` → duration is `0` (not 3000)
- Missing `data-duration` → defaults to `3000`
- `data-duration="5000"` → duration is `5000`
- Mixed frames with zero, positive, and missing durations