### PR TITLE
fix: preserve zero hyperframe durations (#110)

### DIFF
--- a/next/src/lib/__tests__/hyperframes.test.ts
+++ b/next/src/lib/__tests__/hyperframes.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseHyperframes, isHyperframes } from "../hyperframes";
+
+describe("parseHyperframes", () => {
+  it("parses a minimal hyperframes document", () => {
+    const html = `
+      <html>
+        <head><title>Test</title></head>
+        <body class="foo">
+          <section class="frame" data-duration="3000">
+            <p>Frame 1</p>
+          </section>
+          <!-- HYPERFRAMES_META: {"frames":[{"i":1,"duration":3000}]} -->
+        </body>
+      </html>
+    `;
+    const result = parseHyperframes(html);
+    expect(result.isHyperframes).toBe(true);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0].duration).toBe(3000);
+    expect(result.frames[0].innerHtml).toContain("Frame 1");
+    expect(result.title).toBe("Test");
+  });
+
+  it("preserves zero duration from data-duration attribute (issue #110)", () => {
+    const html = `
+      <html>
+        <head><title>Zero Dur</title></head>
+        <body>
+          <section class="frame" data-duration="0">
+            <p>Instant frame</p>
+          </section>
+        </body>
+      </html>
+    `;
+    const result = parseHyperframes(html);
+    expect(result.isHyperframes).toBe(true);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0].duration).toBe(0);
+  });
+
+  it("falls back to default when data-duration is absent", () => {
+    const html = `
+      <html>
+        <head><title>No Dur</title></head>
+        <body>
+          <section class="frame">
+            <p>Frame</p>
+          </section>
+        </body>
+      </html>
+    `;
+    const result = parseHyperframes(html);
+    expect(result.isHyperframes).toBe(true);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0].duration).toBe(3000);
+  });
+
+  it("parses multiple frames with mixed durations including zero", () => {
+    const html = `
+      <html>
+        <head><title>Mixed</title></head>
+        <body>
+          <section class="frame" data-duration="0"><p>A</p></section>
+          <section class="frame" data-duration="1000"><p>B</p></section>
+          <section class="frame"><p>C</p></section>
+        </body>
+      </html>
+    `;
+    const result = parseHyperframes(html);
+    expect(result.frames).toHaveLength(3);
+    expect(result.frames[0].duration).toBe(0);
+    expect(result.frames[1].duration).toBe(1000);
+    expect(result.frames[2].duration).toBe(3000);
+  });
+});
+
+describe("isHyperframes", () => {
+  it("returns false for empty or non-hyperframes html", () => {
+    expect(isHyperframes("")).toBe(false);
+    expect(isHyperframes("<html><body><p>hello</p></body></html>")).toBe(false);
+  });
+
+  it("returns true when at least one frame section exists", () => {
+    const html = `<html><body><section class="frame"><p>hi</p></section></body></html>`;
+    expect(isHyperframes(html)).toBe(true);
+  });
+});

--- a/next/src/lib/__tests__/hyperframes.test.ts
+++ b/next/src/lib/__tests__/hyperframes.test.ts
@@ -39,6 +39,24 @@ describe("parseHyperframes", () => {
     expect(result.frames[0].duration).toBe(0);
   });
 
+  it("preserves zero duration from inline comment marker fallback (issue #110)", () => {
+    const html = `
+      <html>
+        <head><title>Marker Zero</title></head>
+        <body>
+          <section class="frame">
+            <p>Instant frame via marker</p>
+            <!-- frame:1 duration:0 -->
+          </section>
+        </body>
+      </html>
+    `;
+    const result = parseHyperframes(html);
+    expect(result.isHyperframes).toBe(true);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0].duration).toBe(0);
+  });
+
   it("falls back to default when data-duration is absent", () => {
     const html = `
       <html>

--- a/next/src/lib/hyperframes.ts
+++ b/next/src/lib/hyperframes.ts
@@ -78,6 +78,16 @@ function extractAttr(tag: string, name: string): string {
   return pick(re, tag);
 }
 
+function extractOpeningTag(html: string): string {
+  return /<section\b[^>]*>/i.exec(html)?.[0] ?? "";
+}
+
+function parseOptionalDuration(raw: string): number | undefined {
+  if (raw === "") return undefined;
+  const duration = Number(raw);
+  return Number.isFinite(duration) ? duration : undefined;
+}
+
 function parseMeta(html: string): { json: string; entries: HyperframeMetaEntry[] } {
   const raw = pick(META_RE, html).trim();
   if (!raw) return { json: "", entries: [] };
@@ -101,7 +111,7 @@ function parseInlineMarker(innerHtml: string): { duration?: number; transition?:
     innerHtml,
   );
   if (!m) return {};
-  return { duration: Number(m[1]) || undefined, transition: m[2] };
+  return { duration: parseOptionalDuration(m[1]), transition: m[2] };
 }
 
 /**
@@ -136,8 +146,8 @@ export function parseHyperframes(fullHtml: string): HyperframesParsed {
   let idx = 0;
   while ((m = FRAME_RE.exec(fullHtml))) {
     idx += 1;
-    const openTag = pick(/<section\b[^>]*>/i, m[0]);
-    const dataDur = Number(extractAttr(openTag, "data-duration")) || undefined;
+    const openTag = extractOpeningTag(m[0]);
+    const dataDur = parseOptionalDuration(extractAttr(openTag, "data-duration"));
     const dataTransition = extractAttr(openTag, "data-transition") || undefined;
     const inlineStyle = extractAttr(openTag, "style");
     const bg = pick(/background(?:-color)?\s*:\s*([^;"']+)/i, inlineStyle).trim() || undefined;


### PR DESCRIPTION
## Problem

In `next/src/lib/hyperframes.ts`, the `data-duration="0"` attribute was incorrectly treated as `undefined` because:

1. `pick(/<section\b[^>]*>/i, m[0])` returned `undefined` (the regex has no capture group, so `m[1]` is `undefined`)
2. `Number(extractAttr(openTag, "data-duration")) || undefined` treated `0` as falsy and replaced it with `undefined`

This caused all frames with `data-duration="0"` to fall back to the default 3000ms duration.

## Fix

- Added `extractOpeningTag(html)`: returns the matched `<section ...>` tag itself (`m[0]`), so attribute extraction works correctly.
- Added `parseOptionalDuration(raw)`: returns `undefined` only for empty string, preserves `0` as a valid duration.
- Applied both in `parseHyperframes()` and `parseInlineMarker()`.

## Verification

Added `next/src/lib/__tests__/hyperframes.test.ts` with cases covering:
- Zero duration from `data-duration="0"`
- Absent duration falling back to default 3000ms
- Mixed frames with zero, non-zero, and absent durations

All 170 tests pass.

Fixes #110