### PR TITLE
add dark mode toggle to the editor UI

### DIFF
--- a/next/src/app/globals.css
+++ b/next/src/app/globals.css
@@ -35,7 +35,43 @@
   --amber: #b26200;
   --red: #9c2a25;
 
+  --header-bg: rgba(250, 249, 247, 0.92);
+  --grain-a: rgba(106, 92, 56, 0.07);
+  --grain-b: rgba(106, 92, 56, 0.05);
+
   color-scheme: light;
+}
+
+/* ── dark palette — same warm paper/ink language, inverted ──────── */
+:root[data-theme="dark"] {
+  --paper: #16140f;
+  --bone: #1d1a12;
+  --surface: #201d17;
+  --ink: #ece7dc;
+  --ink-soft: #d8d1c2;
+  --ink-mute: #a49b88;
+  --ink-faint: #7b7365;
+  --line: rgba(236, 231, 220, 0.20);
+  --line-soft: rgba(236, 231, 220, 0.11);
+  --line-faint: rgba(236, 231, 220, 0.07);
+
+  --coral: #e07a52;
+  --coral-warm: #f0836a;
+  --coral-hover: #e98d67;
+  --coral-soft: rgba(224, 122, 82, 0.16);
+
+  --olive: #99a068;
+  --green: #4fae6c;
+  --blue: #7d96f0;
+  --purple: #b28ae0;
+  --amber: #dd9a3f;
+  --red: #de6a63;
+
+  --header-bg: rgba(22, 20, 15, 0.92);
+  --grain-a: rgba(233, 185, 74, 0.05);
+  --grain-b: rgba(233, 185, 74, 0.035);
+
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -69,8 +105,8 @@ body::before {
   pointer-events: none;
   z-index: 0;
   background:
-    radial-gradient(circle at 12% 18%, rgba(106, 92, 56, 0.07), transparent 45%),
-    radial-gradient(circle at 88% 72%, rgba(106, 92, 56, 0.05), transparent 50%);
+    radial-gradient(circle at 12% 18%, var(--grain-a), transparent 45%),
+    radial-gradient(circle at 88% 72%, var(--grain-b), transparent 50%);
 }
 
 /* serif italic for accent — open-design hero pattern */

--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
         <script
           dangerouslySetInnerHTML={{
             __html:
-              '(function(){try{var t=localStorage.getItem("html-anything-theme");if(t!=="light"&&t!=="dark")t=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";document.documentElement.dataset.theme=t;}catch(e){}})();',
+              '(function(){var t=null;try{t=localStorage.getItem("html-anything-theme")}catch(e){}if(t!=="light"&&t!=="dark")t=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";document.documentElement.dataset.theme=t;})();',
           }}
         />
         {children}

--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -24,6 +24,12 @@ export default function RootLayout({
         className="min-h-full bg-[var(--paper)] text-[var(--ink)] selection:bg-[var(--coral)]/30"
         suppressHydrationWarning
       >
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              '(function(){try{var t=localStorage.getItem("html-anything-theme");if(t!=="light"&&t!=="dark")t=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";document.documentElement.dataset.theme=t;}catch(e){}})();',
+          }}
+        />
         {children}
       </body>
     </html>

--- a/next/src/components/samples-gallery.tsx
+++ b/next/src/components/samples-gallery.tsx
@@ -111,7 +111,7 @@ export function SamplesGallery({ onLoaded }: { onLoaded?: () => void }) {
                   return (
                     <span key={i}>
                       {kbdParts[0]}
-                      <kbd className="px-1 py-px rounded bg-white border border-[var(--line)] font-mono text-[10px]">
+                      <kbd className="px-1 py-px rounded bg-[var(--surface)] border border-[var(--line)] font-mono text-[10px]">
                         ⌘+Enter
                       </kbd>
                       {kbdParts[1]}

--- a/next/src/components/theme-toggle.tsx
+++ b/next/src/components/theme-toggle.tsx
@@ -1,27 +1,37 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useT } from "@/lib/i18n";
 
 type Theme = "light" | "dark";
 
+// The boot script in layout.tsx applies data-theme before hydration, so the
+// <html> attribute — not React state — is the source of truth for the theme.
+function readTheme(): Theme {
+  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+}
+
+function subscribe(onChange: () => void): () => void {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, { attributeFilter: ["data-theme"] });
+  return () => observer.disconnect();
+}
+
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>("light");
+  // Server snapshot matches the SSR markup; useSyncExternalStore re-reads the
+  // live attribute before first paint, so a dark reload never shows the light
+  // icon, a stale aria-pressed, or a no-op first click.
+  const theme = useSyncExternalStore(subscribe, readTheme, () => "light");
   const t = useT();
 
-  useEffect(() => {
-    setTheme(document.documentElement.dataset.theme === "dark" ? "dark" : "light");
-  }, []);
-
   const toggle = () => {
-    const next: Theme = theme === "dark" ? "light" : "dark";
-    document.documentElement.dataset.theme = next;
+    const next: Theme = readTheme() === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next; // observer re-renders us
     try {
       localStorage.setItem("html-anything-theme", next);
     } catch {
       /* private mode — theme still applies for this session */
     }
-    setTheme(next);
   };
 
   const label = t("toolbar.toggleTheme");

--- a/next/src/components/theme-toggle.tsx
+++ b/next/src/components/theme-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useT } from "@/lib/i18n";
+
+type Theme = "light" | "dark";
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("light");
+  const t = useT();
+
+  useEffect(() => {
+    setTheme(document.documentElement.dataset.theme === "dark" ? "dark" : "light");
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem("html-anything-theme", next);
+    } catch {
+      /* private mode — theme still applies for this session */
+    }
+    setTheme(next);
+  };
+
+  const label = t("toolbar.toggleTheme");
+  return (
+    <button
+      onClick={toggle}
+      className="grid h-9 w-9 place-items-center rounded-full border text-[var(--ink-soft)] transition-all hover:border-[var(--ink)]/30 hover:text-[var(--ink)]"
+      style={{ background: "var(--surface)", borderColor: "var(--line)" }}
+      title={label}
+      aria-label={label}
+      aria-pressed={theme === "dark"}
+    >
+      {theme === "dark" ? (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/next/src/components/toolbar.tsx
+++ b/next/src/components/toolbar.tsx
@@ -6,6 +6,7 @@ import { TemplatePicker } from "./template-picker";
 import { ExportMenu } from "./export-menu";
 import { LayoutModeToggle } from "./layout-mode-toggle";
 import { DeployControl } from "./deploy-control";
+import { ThemeToggle } from "./theme-toggle";
 
 export function Toolbar({
   iframeRef,
@@ -32,7 +33,7 @@ export function Toolbar({
     <header
       className="relative z-40 flex flex-wrap items-center justify-between gap-3 px-5 py-3"
       style={{
-        background: "rgba(250, 249, 247, 0.92)",
+        background: "var(--header-bg)",
         borderBottom: "1px solid var(--line-faint)",
         backdropFilter: "blur(10px)",
       }}
@@ -75,6 +76,7 @@ export function Toolbar({
       <div className="flex items-center gap-2">
         <LayoutModeToggle />
         <div className="hidden h-6 w-px sm:block" style={{ background: "var(--line)" }} />
+        <ThemeToggle />
         <HistoryToggle />
         <button
           onClick={onOpenSettings}

--- a/next/src/lib/i18n.ts
+++ b/next/src/lib/i18n.ts
@@ -19,6 +19,7 @@ export interface Dict {
   "toolbar.selectAgent": string;
   "toolbar.switchAgent": string;
   "toolbar.settings": string;
+  "toolbar.toggleTheme": string;
   "toolbar.stop": string;
   "toolbar.convert": string;
   "toolbar.firstSelectAgent": string;
@@ -381,6 +382,7 @@ const en: Dict = {
   "toolbar.selectAgent": "Select agent",
   "toolbar.switchAgent": "Switch agent",
   "toolbar.settings": "Settings",
+  "toolbar.toggleTheme": "Toggle dark mode",
   "toolbar.stop": "◼ Stop",
   "toolbar.convert": "⚡ Convert to HTML",
   "toolbar.firstSelectAgent": "Pick an agent first",
@@ -743,6 +745,7 @@ const zhCN: Dict = {
   "toolbar.selectAgent": "选择 agent",
   "toolbar.switchAgent": "切换 agent",
   "toolbar.settings": "设置",
+  "toolbar.toggleTheme": "切换深色模式",
   "toolbar.stop": "◼ 停止",
   "toolbar.convert": "⚡ 转换为 HTML",
   "convertChip.label": "生成 HTML",


### PR DESCRIPTION
## Why

The editor chrome is hard-locked to the light paper palette (`color-scheme: light`, no theme mechanism). Anyone working in a dark environment — which is where a lot of agent-driven writing happens — gets a full-brightness white UI with no way out. Since the entire chrome is already driven by the `--paper` / `--ink` / `--surface` CSS variables from the open-design palette, a dark theme is a natural, low-risk variable override rather than a redesign.

## What

- **`globals.css`** — a `:root[data-theme="dark"]` block overriding the palette variables with a warm dark counterpart (same paper/ink language, inverted), plus `color-scheme: dark`. The header background and body grain move into variables (`--header-bg`, `--grain-a/b`) so they track the theme; the default `:root` palette is untouched, so light mode renders exactly as before.
- **`theme-toggle.tsx`** (new) — a sun/moon button in the top bar next to the history toggle, styled like the neighboring round buttons.
- **`layout.tsx`** — a tiny pre-hydration inline script that applies the stored theme (localStorage key `html-anything-theme`) or falls back to `prefers-color-scheme`, so a reload never flashes the wrong theme.
- **`i18n.ts`** — `toolbar.toggleTheme` in both en / zh-CN dicts.
- **`samples-gallery.tsx`** — one `kbd` chip `bg-white` → `var(--surface)` (the only chrome element that bypassed the palette).

Deliberate scope decision: rendered artifacts (preview / deck / history / samples iframes) keep their own colors — generated documents are content, not chrome, and are not re-themed.

## Verification

All CI steps pass locally on this branch:

- `pnpm exec tsx scripts/guard.ts` ✓
- `pnpm -F @html-anything/next typecheck` ✓ · `pnpm -F @html-anything/e2e typecheck` ✓
- `pnpm -F @html-anything/next test` — 172/172 ✓
- `pnpm -F @html-anything/next build` ✓
- `pnpm -F @html-anything/e2e test` — 11/11 ✓

Manually swept in the browser in dark mode: main editor, agent-picker / welcome modal, settings modal, formats & samples galleries, tasks sidebar; toggled both ways and reloaded to confirm persistence and no flash. Light mode is pixel-identical to `main`.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)