### PR TITLE
Fix path resolution leading slash stripping & preserve plaintext agent stream formatting

### DIFF
--- a/cli/src/__tests__/collision-resolve.test.ts
+++ b/cli/src/__tests__/collision-resolve.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, it, expect } from "vitest";
 import { findCommonPath, resolveCollisionOutput } from "../collision-resolve.js";
 

--- a/cli/src/__tests__/collision-resolve.test.ts
+++ b/cli/src/__tests__/collision-resolve.test.ts
@@ -8,17 +8,17 @@ describe("findCommonPath", () => {
   });
 
   it("returns the resolved path of a single input", () => {
-    expect(findCommonPath(["/tmp/x"])).toBe("tmp/x");
+    expect(findCommonPath(["/tmp/x"])).toBe(path.resolve("/tmp/x"));
   });
 
   it("finds the common ancestor of two paths with a shared parent", () => {
     expect(
       findCommonPath(["/home/user/a/b/file.md", "/home/user/a/c/file.md"]),
-    ).toBe("home/user/a");
+    ).toBe(path.resolve("/home/user/a"));
   });
 
   it("returns path.sep when paths share only the root", () => {
-    expect(findCommonPath(["/foo/a.md", "/bar/b.md"])).toBe("/");
+    expect(findCommonPath(["/foo/a.md", "/bar/b.md"])).toBe(path.resolve("/"));
   });
 });
 

--- a/cli/src/agents-invoke.ts
+++ b/cli/src/agents-invoke.ts
@@ -230,12 +230,12 @@ function rescueHtmlFromToolUse(
 }
 
 function parseLineWithState(agent: string, line: string, state: ParseState): AgentParse[] {
+  if (agent === "aider" || agent === "codewhale" || agent === "deepseek-tui") {
+    return [{ kind: "delta", text: line + "\n" }];
+  }
+
   const trimmed = line.trim();
   if (!trimmed) return [];
-
-  if (agent === "aider" || agent === "codewhale" || agent === "deepseek-tui") {
-    return [{ kind: "delta", text: trimmed.endsWith("\n") ? trimmed : trimmed + "\n" }];
-  }
 
   let parsed: unknown;
   try {
@@ -546,7 +546,6 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
           const line = stdoutBuf.slice(0, nl);
           stdoutBuf = stdoutBuf.slice(nl + 1);
-          if (!line) continue;
           for (const part of parse(line)) {
             if (part.kind === "delta") safeEnqueue({ type: "delta", text: part.text });
             else if (part.kind === "html") safeEnqueue({ type: "html", text: part.text });

--- a/cli/src/collision-resolve.ts
+++ b/cli/src/collision-resolve.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 export function findCommonPath(dirs: string[]): string {
   if (dirs.length === 0) return "";
   const resolved = dirs.map((d) => path.resolve(d));
-  const segments = resolved.map((d) => d.split(path.sep).filter(Boolean));
+  const segments = resolved.map((d) => d.split(path.sep));
   const minLen = Math.min(...segments.map((s) => s.length));
   let common = 0;
   for (let i = 0; i < minLen; i++) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -473,7 +473,7 @@ async function convertOne(opts: {
 function findCommonPath(dirs: string[]): string {
   if (dirs.length === 0) return "";
   const resolved = dirs.map((d) => path.resolve(d));
-  const segments = resolved.map((d) => d.split(path.sep).filter(Boolean));
+  const segments = resolved.map((d) => d.split(path.sep));
   const minLen = Math.min(...segments.map((s) => s.length));
   let common = 0;
   for (let i = 0; i < minLen; i++) {

--- a/next/src/lib/agents/argv.ts
+++ b/next/src/lib/agents/argv.ts
@@ -240,14 +240,14 @@ function rescueHtmlFromToolUse(
 }
 
 function parseLineWithState(agent: string, line: string, state: ParseState): AgentParse[] {
-  const trimmed = line.trim();
-  if (!trimmed) return [];
-
   // Aider / DeepSeek — plain text streaming on stdout (DeepSeek tool calls
   // go to stderr, which is forwarded as `stderr` events, not parsed here).
   if (agent === "aider" || agent === "codewhale" || agent === "deepseek-tui") {
-    return [{ kind: "delta", text: trimmed.endsWith("\n") ? trimmed : trimmed + "\n" }];
+    return [{ kind: "delta", text: line + "\n" }];
   }
+
+  const trimmed = line.trim();
+  if (!trimmed) return [];
 
   let parsed: unknown;
   try {

--- a/next/src/lib/agents/invoke.ts
+++ b/next/src/lib/agents/invoke.ts
@@ -213,7 +213,6 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
           const line = stdoutBuf.slice(0, nl);
           stdoutBuf = stdoutBuf.slice(nl + 1);
-          if (!line) continue;
           for (const part of parse(line)) {
             // Some agents (bob) may echo the entire prompt back as the first
             // streamed delta. Suppress that to avoid polluting the user-facing


### PR DESCRIPTION
This PR fixes two issues:
1. Prevents `findCommonPath` from stripping leading slashes on Unix systems when computing common directory roots.
2. Preserves whitespace and empty lines for plaintext streaming agents (`aider`, `codewhale`, `deepseek-tui`) so code blocks and HTML formatting aren't corrupted during streaming.

### Changes
* **Path Resolution (`cli/src/collision-resolve.ts`, `cli/src/index.ts`, `cli/src/__tests__/collision-resolve.test.ts`)**:
  * Removed `.filter(Boolean)` on `path.sep` splits in `findCommonPath` so the root slash isn't lost on Unix systems.
  * Updated `collision-resolve` test assertions to expect resolved absolute paths.

* **Stream Parsing (`cli/src/agents-invoke.ts`, `next/src/lib/agents/invoke.ts`, `next/src/lib/agents/argv.ts`)**:
  * Removed the `if (!line) continue` check in the stream processing loops.
  * Preserved raw line content (including leading spaces and blank lines) for plain-text streaming agents instead of trimming them.

### Testing
* Ran unit tests for path collision resolution.
* Verified stream outputs for plain-text agents preserve indentation and newlines.