### PR TITLE
docs: add Floatboat community integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ On startup we scan `PATH` (including `~/.local/bin`, `~/.bun/bin`, `/opt/homebre
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
 | **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
+| **[Floatboat](https://floatboat.ai/combostore/html-anything-3ERkni)** | Floatboat Combo Skill Store | In-app invocation: install and use the **html-anything** Combo Skill in Floatboat |
 
 > The detection strategy and per-CLI adapter shape are borrowed directly from [`nexu-io/open-design`](https://github.com/nexu-io/open-design) and [`multica-ai/multica`](https://github.com/multica-ai/multica): one privileged process spawns CLIs, JSON-line is the wire protocol, every CLI gets a thin adapter in [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts).
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you've already done `claude login` / `cursor login` / `gemini auth` in your t
 
 ## Community integrations
 
-### [Floatboat](https://floatboat.ai/combostore/html-anything-3ERkni)
+### [Floatboat](https://floatboat.ai/combostore/html-anything-4a58QO)
 
 Floatboat is available as an in-app community integration. Install the **html-anything** Combo Skill from the Floatboat Combo Skill Store, then use it inside Floatboat.
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,29 @@ On startup we scan `PATH` (including `~/.local/bin`, `~/.bun/bin`, `/opt/homebre
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
 | **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
-| **[Floatboat](https://floatboat.ai/combostore/html-anything-3ERkni)** | Floatboat Combo Skill Store | In-app invocation: install and use the **html-anything** Combo Skill in Floatboat |
 
 > The detection strategy and per-CLI adapter shape are borrowed directly from [`nexu-io/open-design`](https://github.com/nexu-io/open-design) and [`multica-ai/multica`](https://github.com/multica-ai/multica): one privileged process spawns CLIs, JSON-line is the wire protocol, every CLI gets a thin adapter in [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts).
 
 If you've already done `claude login` / `cursor login` / `gemini auth` in your terminal, HTML Anything reuses that session. **No second copy of the API key required.**
+
+## Community integrations
+
+### [Floatboat](https://floatboat.ai/combostore/html-anything-3ERkni)
+
+Floatboat is available as an in-app community integration. Install the **html-anything** Combo Skill from the Floatboat Combo Skill Store, then use it inside Floatboat.
+
+<table>
+<tr>
+<td width="50%">
+<img src="https://github.com/user-attachments/assets/6049b725-811c-490a-93ec-4d60436e6c98" alt="HTML Anything running inside the Floatboat workspace" /><br/>
+<sub><b>In-app workflow</b> — Review the task context, HTML Anything workspace, and generated page side by side in Floatboat.</sub>
+</td>
+<td width="50%">
+<img src="https://github.com/user-attachments/assets/0f1c584a-8b5c-428a-b16c-4be3bdfc70e5" alt="HTML deliverable created with HTML Anything in Floatboat" /><br/>
+<sub><b>Deliverable preview</b> — Turn a brief into a polished HTML page and review the result in Floatboat.</sub>
+</td>
+</tr>
+</table>
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,11 +203,29 @@ pnpm -F @html-anything/e2e test
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
 | **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
-| **[Floatboat](https://floatboat.ai/zh/combostore/html-anything-02HZ2i)** | Floatboat Combo Skill Store | 应用内调用：在 Floatboat 中安装并使用 **html-anything** Combo Skill |
 
 > 这一层的设计直接借鉴了 [`nexu-io/open-design`](https://github.com/nexu-io/open-design) 和 [`multica-ai/multica`](https://github.com/multica-ai/multica) 的 agent 检测策略：唯一被 spawn 子进程的进程是 server route，业务进程不直接 spawn；CLI 的 stdin / stdout 用 JSON-line 协议复用，每个 CLI 一个轻 adapter，统一在 [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts)。
 
 只要你已经在终端里登录过对应的 CLI（例如 `claude login`、`cursor login`），HTML Anything 直接复用同一个 session，**不要求你再贴一遍 API Key**。
+
+## 🤝 社区集成
+
+### [Floatboat](https://floatboat.ai/zh/combostore/html-anything-2bHaqL)
+
+Floatboat 可作为应用内社区集成使用。请先在 Floatboat Combo Skill Store 安装 **html-anything** Combo Skill，再在 Floatboat 应用内使用该 Skill。
+
+<table>
+<tr>
+<td width="50%">
+<img src="https://github.com/user-attachments/assets/6049b725-811c-490a-93ec-4d60436e6c98" alt="Floatboat 工作区中的 HTML Anything 任务流程" /><br/>
+<sub><b>端内工作流</b> —— 在 Floatboat 中并排查看任务上下文、HTML Anything 工作区与生成页面。</sub>
+</td>
+<td width="50%">
+<img src="https://github.com/user-attachments/assets/0f1c584a-8b5c-428a-b16c-4be3bdfc70e5" alt="在 Floatboat 中通过 HTML Anything 创建的 HTML 成品" /><br/>
+<sub><b>成品预览</b> —— 将任务需求转化为可阅读的 HTML 页面，并在 Floatboat 中查看结果。</sub>
+</td>
+</tr>
+</table>
 
 ## 🎨 Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,7 @@ pnpm -F @html-anything/e2e test
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
 | **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
+| **[Floatboat](https://floatboat.ai/zh/combostore/html-anything-3ERkni)** | Floatboat Combo Skill Store | 应用内调用：在 Floatboat 中安装并使用 **html-anything** Combo Skill |
 
 > 这一层的设计直接借鉴了 [`nexu-io/open-design`](https://github.com/nexu-io/open-design) 和 [`multica-ai/multica`](https://github.com/multica-ai/multica) 的 agent 检测策略：唯一被 spawn 子进程的进程是 server route，业务进程不直接 spawn；CLI 的 stdin / stdout 用 JSON-line 协议复用，每个 CLI 一个轻 adapter，统一在 [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,7 +203,7 @@ pnpm -F @html-anything/e2e test
 | **Qwen Coder** | `qwen` | `qwen --yolo -` |
 | **Aider** | `aider` | `aider --no-pretty --no-stream --yes-always --message-file -` |
 | **IBM Bob** | `bob` | `bob --output-format stream-json --hide-intermediary-output` |
-| **[Floatboat](https://floatboat.ai/zh/combostore/html-anything-3ERkni)** | Floatboat Combo Skill Store | 应用内调用：在 Floatboat 中安装并使用 **html-anything** Combo Skill |
+| **[Floatboat](https://floatboat.ai/zh/combostore/html-anything-02HZ2i)** | Floatboat Combo Skill Store | 应用内调用：在 Floatboat 中安装并使用 **html-anything** Combo Skill |
 
 > 这一层的设计直接借鉴了 [`nexu-io/open-design`](https://github.com/nexu-io/open-design) 和 [`multica-ai/multica`](https://github.com/multica-ai/multica) 的 agent 检测策略：唯一被 spawn 子进程的进程是 server route，业务进程不直接 spawn；CLI 的 stdin / stdout 用 JSON-line 协议复用，每个 CLI 一个轻 adapter，统一在 [`next/src/lib/agents/argv.ts`](next/src/lib/agents/argv.ts)。
 


### PR DESCRIPTION
## Summary

- Add a Floatboat entry under Community integrations.
- Show an end-to-end HTML Anything workflow inside Floatboat: task context enters the built-in automation browser, the resulting web deliverable is reviewed at a desktop width, and task history / generation logs remain visible in the Agent Workspace.
- Add two evidence screenshots: the in-app automation runtime and the desktop deliverable.

## Validation

- Verified each screenshot path from both README additions.
- Reviewed the generated landing page at a desktop width.
- Offline inspection completed with 0 errors and 0 warnings.
