### PR TITLE
Support OpenClaw multiline prompt from a file

### DIFF
--- a/cli/src/__tests__/agents-invoke.test.ts
+++ b/cli/src/__tests__/agents-invoke.test.ts
@@ -1,6 +1,8 @@
 import { vi, describe, it, expect, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
 
 const { mockSpawn, existsSyncDelegate } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
@@ -16,7 +18,7 @@ vi.mock("node:fs", async () => {
   return { ...actual, existsSync: existsSyncDelegate };
 });
 
-import { invokeAgent, type InvokeEvent } from "../agents-invoke.js";
+import { invokeAgent, createMessageFile, type InvokeEvent } from "../agents-invoke.js";
 
 function makeFakeChild() {
   const stdout = new PassThrough();
@@ -32,6 +34,7 @@ function makeFakeChild() {
     stdout,
     stderr,
     pid: 99999,
+    kill: () => true,
   });
 
   return { child, stdout, stderr, stdin };
@@ -526,5 +529,101 @@ describe("invokeAgent", () => {
       expect(htmls).toHaveLength(0);
     });
 
+  });
+});
+
+describe("createMessageFile", () => {
+  it("returns distinct files with intact contents for invocations created in the same millisecond", () => {
+    const handles: ReturnType<typeof createMessageFile>[] = [];
+    for (let i = 0; i < 25; i++) {
+      handles.push(createMessageFile(`prompt-${i}`));
+    }
+
+    const paths = new Set(handles.map((h) => h.filePath));
+    expect(paths.size).toBe(handles.length);
+
+    handles.forEach((h, i) => {
+      expect(readFileSync(h.filePath, "utf8")).toBe(`prompt-${i}`);
+    });
+
+    for (const h of handles) {
+      h.cleanup();
+      h.cleanup();
+    }
+    const remaining = handles.filter(
+      (h) => statSync(path.dirname(h.filePath), { throwIfNoEntry: false }) !== undefined,
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it(
+    "creates the prompt file with restrictive permissions (not relying on umask)",
+    { skip: process.platform === "win32" },
+    () => {
+      const h = createMessageFile("secret");
+      expect(statSync(path.dirname(h.filePath)).mode & 0o777).toBe(0o700);
+      expect(statSync(h.filePath).mode & 0o777).toBe(0o600);
+      h.cleanup();
+    },
+  );
+});
+
+describe("openclaw file-protocol prompt file concurrency", () => {
+  it("passes distinct prompt files to concurrent invocations and cleanup of one does not affect the other", async () => {
+    const messagePaths: string[] = [];
+    const invokeChildren: ReturnType<typeof makeFakeChild>["child"][] = [];
+    mockSpawn.mockImplementation((_bin: string, argv: string[]) => {
+      if (argv[0] === "agents" && argv[1] === "list") {
+        const listFake = makeFakeChild();
+        queueMicrotask(() => {
+          listFake.stdout.write("- main-agent\n");
+          listFake.stdout.end();
+          listFake.child.emit("close", 0);
+        });
+        return listFake.child;
+      }
+      const idx = argv.indexOf("--message-file");
+      if (idx !== -1) messagePaths.push(argv[idx + 1]);
+      const fake = makeFakeChild();
+      invokeChildren.push(fake.child);
+      return fake.child;
+    });
+
+    const streamA = invokeAgent({
+      agent: "openclaw",
+      prompt: "PROMPT-A",
+      binOverride: BIN_OVERRIDE,
+    });
+    const streamB = invokeAgent({
+      agent: "openclaw",
+      prompt: "PROMPT-B",
+      binOverride: BIN_OVERRIDE,
+    });
+
+    for (let i = 0; i < 200 && (messagePaths.length < 2 || invokeChildren.length < 2); i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    const eventsA = collectStream(streamA);
+    const eventsB = collectStream(streamB);
+
+    expect(messagePaths).toHaveLength(2);
+    expect(messagePaths[0]).not.toBe(messagePaths[1]);
+    const contents = new Set(messagePaths.map((p) => readFileSync(p, "utf8")));
+    expect(contents).toEqual(new Set(["PROMPT-A", "PROMPT-B"]));
+    const contentBefore = messagePaths.map((p) => readFileSync(p, "utf8"));
+
+    invokeChildren[0].stdout.end();
+    invokeChildren[0].emit("close", 0);
+    await eventsA;
+
+    expect(statSync(messagePaths[1], { throwIfNoEntry: false })).toBeDefined();
+    expect(readFileSync(messagePaths[1], "utf8")).toBe(contentBefore[1]);
+
+    invokeChildren[1].stdout.end();
+    invokeChildren[1].emit("close", 0);
+    await eventsB;
+
+    expect(statSync(messagePaths[0], { throwIfNoEntry: false })).toBeUndefined();
+    expect(statSync(messagePaths[1], { throwIfNoEntry: false })).toBeUndefined();
   });
 });

--- a/cli/src/agents-detect.ts
+++ b/cli/src/agents-detect.ts
@@ -6,7 +6,7 @@ import path, { delimiter, join } from "node:path";
  * Agent detection — adapted from next/src/lib/agents/detect.ts
  */
 
-export type AgentProtocol = "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc";
+export type AgentProtocol = "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc" | "file";
 
 export type ModelOption = { id: string; label: string };
 
@@ -47,7 +47,7 @@ export const AGENTS: AgentDef[] = [
     bin: "openclaw",
     envOverride: "OPENCLAW_BIN",
     vendor: "OpenClaw multi-channel agent gateway",
-    protocol: "argv-message",
+    protocol: "file",
     fallbackModels: [
       DEFAULT_MODEL,
       { id: "openrouter/anthropic/claude-opus-4.7", label: "Opus 4.7 (OpenRouter)" },

--- a/cli/src/agents-invoke.ts
+++ b/cli/src/agents-invoke.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { resolveOnPath, AGENTS, type AgentDef, type AgentProtocol } from "./agents-detect.js";
 
 export type InvokeOpts = {
@@ -183,6 +184,18 @@ function envFor(agent: string): NodeJS.ProcessEnv {
   const base = { ...process.env };
   if (agent === "gemini") base.GEMINI_CLI_TRUST_WORKSPACE = "true";
   return base;
+}
+
+export function createMessageFile(prompt: string): {filePath: string; cleanup: () => void;} {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "html-anything-agent-message-"));
+  const filePath = path.join(dir, "message.txt");
+  writeFileSync(filePath, prompt, { encoding: "utf8", mode: 0o600 });
+  const cleanup = () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  };
+  return { filePath, cleanup };
 }
 
 // ─── stdout parser ────────────────────────────────────────────────────
@@ -458,11 +471,13 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
   const env = envFor(opts.agent);
   const promptViaArgv = def.protocol === "argv";
   const promptViaMessageFlag = def.protocol === "argv-message";
+  const promptViaFileFlag = def.protocol === "file";
 
   return new ReadableStream<InvokeEvent>({
     async start(controller) {
       let closed = false;
       let child: ChildProcessWithoutNullStreams | null = null;
+      let messageFile: { filePath: string; cleanup: () => void } | undefined;
 
       const safeEnqueue = (ev: InvokeEvent) => {
         if (closed) return;
@@ -478,6 +493,12 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         try {
           controller.close();
         } catch {}
+      };
+      const cleanupMessageFile = () => {
+        if (messageFile) {
+          messageFile.cleanup();
+          messageFile = undefined;
+        }
       };
 
       let argv: string[];
@@ -504,7 +525,10 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
       }
       if (promptViaArgv) argv = [...argv, opts.prompt];
       if (promptViaMessageFlag) argv = [...argv, "--message", opts.prompt];
-
+      if (promptViaFileFlag) {
+        messageFile = createMessageFile(opts.prompt);
+        argv = [...argv, "--message-file", messageFile.filePath];
+      }
       try {
         child = spawn(bin, argv, {
           cwd: opts.cwd ?? process.cwd(),
@@ -517,6 +541,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           type: "error",
           message: err instanceof Error ? err.message : String(err),
         });
+        cleanupMessageFile();
         safeClose();
         return;
       }
@@ -563,6 +588,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
 
       child.on("error", (err) => {
         safeEnqueue({ type: "error", message: err.message });
+        cleanupMessageFile();
         safeClose();
       });
 
@@ -604,6 +630,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           }
         }
         safeEnqueue({ type: "done", code });
+        cleanupMessageFile();
         safeClose();
       });
 
@@ -611,6 +638,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         try {
           child?.kill("SIGTERM");
         } catch {}
+        cleanupMessageFile();
         safeClose();
       };
       opts.signal?.addEventListener("abort", onAbort, { once: true });

--- a/next/src/components/settings-modal.tsx
+++ b/next/src/components/settings-modal.tsx
@@ -32,6 +32,7 @@ const PROTOCOL_KEY: Record<AgentInfo["protocol"], { key: DictKey; tone: "ok" | "
   "argv-message": { key: "protocol.argvMessage", tone: "ok" },
   acp: { key: "protocol.acp", tone: "warn" },
   "pi-rpc": { key: "protocol.piRpc", tone: "warn" },
+  file: { key: "protocol.file", tone: "ok" },
 };
 
 const VENDOR_GRADIENT: Record<string, string> = {

--- a/next/src/components/welcome-modal.tsx
+++ b/next/src/components/welcome-modal.tsx
@@ -10,6 +10,7 @@ const PROTOCOL_KEY: Record<AgentInfo["protocol"], { key: DictKey; tone: "ok" | "
   "argv-message": { key: "protocol.argvMessage", tone: "ok" },
   acp: { key: "protocol.acp", tone: "warn" },
   "pi-rpc": { key: "protocol.piRpc", tone: "warn" },
+  file: { key: "protocol.file", tone: "ok" },
 };
 
 const VENDOR_HINT: Record<string, { gradient: string; install: string }> = {

--- a/next/src/lib/agents/__tests__/invoke.test.ts
+++ b/next/src/lib/agents/__tests__/invoke.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { chmodSync, mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { invokeAgent, createMessageFile, type InvokeEvent } from "../invoke";
+
+const BIN_OVERRIDE = process.execPath;
+
+describe("createMessageFile", () => {
+  it("returns distinct files with intact contents for invocations created in the same millisecond", () => {
+    const handles: ReturnType<typeof createMessageFile>[] = [];
+    for (let i = 0; i < 25; i++) {
+      handles.push(createMessageFile(`prompt-${i}`));
+    }
+
+    const paths = new Set(handles.map((h) => h.filePath));
+    expect(paths.size).toBe(handles.length);
+
+    handles.forEach((h, i) => {
+      expect(readFileSync(h.filePath, "utf8")).toBe(`prompt-${i}`);
+    });
+
+    for (const h of handles) {
+      h.cleanup();
+      h.cleanup();
+    }
+    const remaining = handles.filter(
+      (h) => statSync(path.dirname(h.filePath), { throwIfNoEntry: false }) !== undefined,
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it(
+    "creates the prompt file with restrictive permissions (not relying on umask)",
+    { skip: process.platform === "win32" },
+    () => {
+      const h = createMessageFile("secret");
+      expect(statSync(path.dirname(h.filePath)).mode & 0o777).toBe(0o700);
+      expect(statSync(h.filePath).mode & 0o777).toBe(0o600);
+      h.cleanup();
+    },
+  );
+});
+
+describe("openclaw file-protocol prompt file concurrency", () => {
+  let stubDir: string;
+  let stubBin: string;
+
+  beforeAll(() => {
+    stubDir = mkdtempSync(path.join(os.tmpdir(), "html-anything-agent-stub-"));
+    writeFileSync(
+      path.join(stubDir, "stub.js"),
+      [
+        `const { readFileSync } = require("node:fs");`,
+        `const argv = process.argv.slice(2);`,
+        `const idx = argv.indexOf("--message-file");`,
+        `let content = "";`,
+        `let file = "";`,
+        `if (idx !== -1) {`,
+        `  file = argv[idx + 1];`,
+        `  try {`,
+        `    content = readFileSync(file, "utf8");`,
+        `  } catch {`,
+        `    content = "STUB_READ_ERROR";`,
+        `  }`,
+        `}`,
+        `process.stdout.write(JSON.stringify({`,
+        `  meta: { finalAssistantVisibleText: content, agentMeta: { sessionId: file } },`,
+        `}));`,
+        ``,
+      ].join("\n"),
+    );
+    if (process.platform === "win32") {
+      stubBin = path.join(stubDir, "stub.cmd");
+      writeFileSync(stubBin, `@echo off\r\nnode "%~dp0stub.js" %*\r\n`);
+    } else {
+      stubBin = path.join(stubDir, "stub.sh");
+      writeFileSync(stubBin, `#!/bin/sh\nexec node "$(dirname "$0")/stub.js" "$@"\n`);
+      chmodSync(stubBin, 0o755);
+    }
+  });
+
+  afterAll(() => {
+    rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it("passes distinct prompt files to concurrent invocations and cleanup of one does not affect the other", async () => {
+    const streamA = invokeAgent({
+      agent: "openclaw",
+      prompt: "PROMPT-A",
+      binOverride: stubBin,
+    });
+    const streamB = invokeAgent({
+      agent: "openclaw",
+      prompt: "PROMPT-B",
+      binOverride: stubBin,
+    });
+
+    const [eventsA, eventsB] = await Promise.all([
+      collectStream(streamA),
+      collectStream(streamB),
+    ]);
+
+    const deltaA = eventsA.find((e): e is Extract<InvokeEvent, { type: "delta" }> => e.type === "delta");
+    const deltaB = eventsB.find((e): e is Extract<InvokeEvent, { type: "delta" }> => e.type === "delta");
+    expect(deltaA).toBeDefined();
+    expect(deltaB).toBeDefined();
+    expect([deltaA!.text, deltaB!.text].sort()).toEqual(["PROMPT-A", "PROMPT-B"]);
+
+    const sessionA = eventsA.find(
+      (e): e is Extract<InvokeEvent, { type: "meta" }> => e.type === "meta" && e.key === "session",
+    );
+    const sessionB = eventsB.find(
+      (e): e is Extract<InvokeEvent, { type: "meta" }> => e.type === "meta" && e.key === "session",
+    );
+    expect(sessionA).toBeDefined();
+    expect(sessionB).toBeDefined();
+    expect(sessionA!.value).not.toBe(sessionB!.value);
+
+    expect(statSync(path.dirname(sessionA!.value as string), { throwIfNoEntry: false })).toBeUndefined();
+    expect(statSync(path.dirname(sessionB!.value as string), { throwIfNoEntry: false })).toBeUndefined();
+  });
+});
+
+async function collectStream(
+  stream: ReadableStream<InvokeEvent>,
+): Promise<InvokeEvent[]> {
+  const events: InvokeEvent[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) events.push(value);
+  }
+  return events;
+}

--- a/next/src/lib/agents/detect.ts
+++ b/next/src/lib/agents/detect.ts
@@ -7,7 +7,7 @@ import path, { delimiter, join } from "node:path";
  * prompt and how it parses output:
  *   - "stdin"        : pipe prompt → child stdin, parse stdout via parseLine
  *   - "argv"         : pass prompt as positional argv (deepseek-tui), parse stdout as plain
- *   - "argv-message" : prompt goes via `--message <text>` (openclaw); stdout is
+ *   - "argv-message" : prompt goes via `--message <text>` (openclaw)(older); stdout is
  *                      a single multi-line JSON document (not ndjson), parsed
  *                      after the child closes.
  *   - "acp"          : ACP JSON-RPC over stdio (hermes/kimi/devin/kiro/kilo/vibe).
@@ -15,8 +15,11 @@ import path, { delimiter, join } from "node:path";
  *                      the user sees install instructions, but invoke emits a
  *                      clear error pointing them to a supported agent.
  *   - "pi-rpc"       : pi's custom JSON-RPC mode. Same status as "acp".
+ *   - "file"         : prompt goes via `--message-file <file-path>` (openclaw)(newer); stdout is
+ *                      a single multi-line JSON document (not ndjson), parsed
+ *                      after the child closes.
  */
-export type AgentProtocol = "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc";
+export type AgentProtocol = "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc" | "file";
 
 export type ModelOption = { id: string; label: string };
 
@@ -64,15 +67,15 @@ export const AGENTS: AgentDef[] = [
   },
   {
     // OpenClaw is a multi-channel agent gateway, not a Claude-CLI fork —
-    // its CLI surface is `openclaw agent --message <text>` and it returns a
-    // single multi-line JSON blob (no streaming). The "argv-message"
-    // protocol covers the prompt-via-flag and post-close JSON parse.
+    // its CLI surface is `openclaw agent --message <text>` or `openclaw agent --message-file <text>` and it returns a
+    // single multi-line JSON blob (no streaming). Ues the "file"
+    // protocol covers the multiline prompt-via-flag and post-close JSON parse.
     id: "openclaw",
     label: "OpenClaw",
     bin: "openclaw",
     envOverride: "OPENCLAW_BIN",
     vendor: "OpenClaw multi-channel agent gateway",
-    protocol: "argv-message",
+    protocol: "file",
     fallbackModels: [
       DEFAULT_MODEL,
       // Models surface as overrides for OpenClaw's routing; the CLI accepts

--- a/next/src/lib/agents/invoke.ts
+++ b/next/src/lib/agents/invoke.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { resolveOnPath, resolveOpenclawAgentId, AGENTS } from "./detect";
 import { buildArgv, envFor, makeParser, UnsupportedAgentProtocolError } from "./argv";
 
@@ -63,6 +65,18 @@ function resolveBinForAgent(
   return { kind: "not-found" };
 }
 
+export function createMessageFile(prompt: string): { filePath: string; cleanup: () => void; } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "html-anything-agent-message-"));
+  const filePath = path.join(dir, "message.txt");
+  writeFileSync(filePath, prompt, { encoding: "utf8", mode: 0o600 });
+  const cleanup = () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  };
+  return { filePath, cleanup };
+}
+
 export type InvokeEvent =
   | { type: "start"; bin: string; argv: string[]; promptBytes: number }
   | { type: "delta"; text: string }
@@ -102,11 +116,13 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
   const env = envFor(opts.agent);
   const promptViaArgv = def.protocol === "argv";
   const promptViaMessageFlag = def.protocol === "argv-message";
+  const promptViaFileFlag = def.protocol === "file";
 
   return new ReadableStream<InvokeEvent>({
     async start(controller) {
       let closed = false;
       let child: ChildProcessWithoutNullStreams | null = null;
+      let messageFile: { filePath: string; cleanup: () => void } | undefined;
 
       const safeEnqueue = (ev: InvokeEvent) => {
         if (closed) return;
@@ -122,6 +138,12 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         try {
           controller.close();
         } catch {}
+      };
+      const cleanupMessageFile = () => {
+        if (messageFile) {
+          messageFile.cleanup();
+          messageFile = undefined;
+        }
       };
 
       // Resolve agent-specific argv. For openclaw we first probe `agents
@@ -153,9 +175,13 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
       // `protocol: "argv"` adapters (deepseek-tui today) take the prompt as a
       // trailing positional arg rather than reading from stdin.
       if (promptViaArgv) argv = [...argv, opts.prompt];
-      // `protocol: "argv-message"` (openclaw today) wants the prompt under
       // an explicit `--message <text>` flag.
       if (promptViaMessageFlag) argv = [...argv, "--message", opts.prompt];
+      // `protocol: "file"` (openclaw today) wants the prompt under a file
+      if (promptViaFileFlag) {
+        messageFile = createMessageFile(opts.prompt);
+        argv = [...argv, "--message-file", messageFile.filePath];
+      }
 
       try {
         // On Windows, `spawn` cannot launch a `.cmd` / `.bat` shim (which is
@@ -178,6 +204,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           type: "error",
           message: err instanceof Error ? err.message : String(err),
         });
+        cleanupMessageFile();
         safeClose();
         return;
       }
@@ -236,6 +263,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
 
       child.on("error", (err) => {
         safeEnqueue({ type: "error", message: err.message });
+        cleanupMessageFile();
         safeClose();
       });
 
@@ -303,6 +331,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
           }
         }
         safeEnqueue({ type: "done", code });
+        cleanupMessageFile();
         safeClose();
       });
 
@@ -310,6 +339,7 @@ export function invokeAgent(opts: InvokeOpts): ReadableStream<InvokeEvent> {
         try {
           child?.kill("SIGTERM");
         } catch {}
+        cleanupMessageFile();
         safeClose();
       };
       opts.signal?.addEventListener("abort", onAbort, { once: true });

--- a/next/src/lib/i18n.ts
+++ b/next/src/lib/i18n.ts
@@ -85,6 +85,7 @@ export interface Dict {
   "protocol.argvMessage": string;
   "protocol.acp": string;
   "protocol.piRpc": string;
+  "protocol.file": string;
 
   // Settings modal
   "settings.eyebrow": string;
@@ -445,6 +446,7 @@ const en: Dict = {
   "protocol.argvMessage": "argv · batch JSON",
   "protocol.acp": "ACP JSON-RPC · not wired",
   "protocol.piRpc": "pi-rpc · not wired",
+  "protocol.file": "argv · file prompt",
 
   "settings.eyebrow": "Settings",
   "settings.titlePart1": "Configure",
@@ -806,6 +808,7 @@ const zhCN: Dict = {
   "protocol.argvMessage": "argv · 整段 JSON",
   "protocol.acp": "ACP JSON-RPC · 暂未接入",
   "protocol.piRpc": "pi-rpc · 暂未接入",
+  "protocol.file": "argv · 文件传参",
 
   "settings.eyebrow": "设置",
   "settings.titlePart1": "配置",

--- a/next/src/lib/store.ts
+++ b/next/src/lib/store.ts
@@ -14,7 +14,7 @@ export type AgentInfo = {
   available: boolean;
   path?: string;
   /** UI uses this to badge unsupported / batch adapters. Mirrors AgentProtocol on the server. */
-  protocol: "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc";
+  protocol: "stdin" | "argv" | "argv-message" | "acp" | "pi-rpc" | "file";
   /** Curated model list for the picker. Always begins with `default`. */
   models: ModelOption[];
   /** True for ACP / pi-rpc adapters where Convert returns a friendly error. */


### PR DESCRIPTION
The current version of OpenClaw has an issue where line breaks in multi-line prompts cause data loss.
Implement integration with OpenClaw's latest [`--message-file`](https://docs.openclaw.ai/tools/agent-send) capability, supporting the use of files to handle multi-line prompts.

**Test Result:**
<img width="2278" height="939" alt="image" src="https://github.com/user-attachments/assets/f4921a1d-06ac-479e-a1fe-a106bb6baad6" />


